### PR TITLE
Add multi-horizon forecast reliability

### DIFF
--- a/.github/workflows/forecast.yml
+++ b/.github/workflows/forecast.yml
@@ -42,7 +42,7 @@ jobs:
           restore-keys: |
             timesfm-3-${{ runner.os }}-
 
-      - name: Restore previous forecast state
+      - name: Restore forecast history
         uses: actions/cache/restore@v4
         with:
           path: .state/previous_forecast.json
@@ -55,7 +55,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Forecast BTC and score previous prediction
+      - name: Forecast BTC and score matured predictions
         run: python btc_forecast.py
 
       - name: Add forecast to job summary
@@ -68,12 +68,7 @@ jobs:
           echo '## X post' >> "$GITHUB_STEP_SUMMARY"
           cat tweet.txt >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Prepare next forecast state
-        run: |
-          mkdir -p .state
-          cp forecast.json .state/previous_forecast.json
-
-      - name: Save forecast state
+      - name: Save forecast history
         uses: actions/cache/save@v4
         with:
           path: .state/previous_forecast.json

--- a/README.md
+++ b/README.md
@@ -27,55 +27,52 @@ GitHub Actions runs every 2 hours, at minute `17` UTC:
 
 Scheduled runs post the forecast to X automatically. Manual runs can optionally post by enabling the `post_to_x` workflow input.
 
-## Previous forecast reliability
+## Multi-horizon forecast reliability
 
-Each run restores the previous forecast from the GitHub Actions cache and evaluates its **+2h prediction** against the exact completed Kraken hourly candle that corresponds to that forecast target.
+The workflow keeps a rolling history of recent forecasts and scores the most recent matured prediction for each horizon: **2h, 4h, 8h and 16h**.
 
-The reliability block records:
+For example, at a 12:00 run:
 
+- the 2h comparison comes from the forecast issued around 10:00
+- the 4h comparison comes from the forecast issued around 08:00
+- the 8h comparison comes from the forecast issued around 04:00
+- the 16h comparison comes from the forecast issued around 20:00 the previous day
+
+Each score is matched to the exact completed Kraken hourly candle at that prediction's target timestamp. The reliability block records:
+
+- predicted and actual price
 - absolute price error in USD
 - absolute percentage error
 - predicted vs actual percentage change
 - whether the predicted direction was correct
-- whether the actual price landed inside the previous Q10-Q90 interval
+- whether the actual price landed inside the forecast Q10-Q90 interval
 
-The first run has no previous forecast to score. If a run is delayed or skipped, the script uses the timestamp of the previous forecast target rather than blindly comparing with the latest price.
+The forecast history keeps up to 48 snapshots and is persisted through the GitHub Actions cache. The old single-forecast cache format is migrated automatically on the first run.
+
+A fresh history needs time to mature: 2h accuracy appears first, then 4h, 8h and finally 16h after enough scheduled runs have accumulated.
 
 ## X / Twitter posting with Twikit
 
-The workflow generates a `tweet.txt` file with the current forecasts and the previous +2h reliability result, for example:
+The workflow generates a `tweet.txt` file with current forecasts plus the latest available error for each horizon, for example:
 
 ```text
 BTC/USD - TimesFM 3
 Now $100,000
 2h $100,200 (+0.20%) | 4h $100,450 (+0.45%)
 8h $100,800 (+0.80%) | 16h $101,100 (+1.10%)
-Prev +2h: 0.31% error | direction OK | in range
+Prev err: 2h 0.31% | 4h 0.42% | 8h 0.75% | 16h 1.10%
 Experimental - not financial advice.
 ```
 
-Posting uses **Twikit 2.3.3** and an authenticated X web-session cookie. It does **not** use X's paid developer API, so the previous `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, and `X_ACCESS_TOKEN_SECRET` secrets are no longer required by this branch.
+Posting uses **Twikit 2.3.3** and an authenticated X web-session cookie. It does **not** use X's paid developer API.
 
-Twikit is an unofficial X/Twitter client. It can break when X changes its internal endpoints, and X may reject activity that looks automated. Reuse the same session instead of logging in on every workflow run, keep the posting rate modest, and be prepared to refresh the session if X invalidates it.
+Twikit is an unofficial X/Twitter client. It can break when X changes its internal endpoints, and X may reject activity that looks automated. Reuse the same session, keep the posting rate modest, and refresh the browser session cookie if X invalidates it.
 
-### 1. Get the X session cookies from your browser
+### X session cookies
 
-Open `https://x.com` in a desktop browser where you are already logged in.
+Open `https://x.com` in a desktop browser where you are logged in and copy the `auth_token` and `ct0` cookies from the browser developer tools.
 
-In Chrome, Edge or Brave:
-
-1. Open Developer Tools.
-2. Go to **Application -> Storage -> Cookies -> https://x.com**.
-3. Copy the values of `auth_token` and `ct0`.
-
-In Safari on macOS:
-
-1. Enable **Safari -> Settings -> Advanced -> Show features for web developers**.
-2. Open the Web Inspector for `x.com`.
-3. Go to **Storage -> Cookies**.
-4. Copy the values of `auth_token` and `ct0`.
-
-Create a temporary local file named `x_cookies.json`:
+Create a temporary local file:
 
 ```json
 {
@@ -84,61 +81,20 @@ Create a temporary local file named `x_cookies.json`:
 }
 ```
 
-Additional X cookies may be included, but `auth_token` and `ct0` are the ones required by `post_to_x.py`.
-
-Treat this file like a password. It is ignored by `.gitignore` and must never be committed.
-
-### 2. Store the session in GitHub Actions
-
-The workflow expects one repository secret:
-
-```text
-X_COOKIES_JSON
-```
-
-With GitHub CLI:
+Store it as the repository secret:
 
 ```bash
 gh secret set X_COOKIES_JSON --repo jpfelgueiras/btc-timesfm < x_cookies.json
-```
-
-Or with the GitHub UI:
-
-1. Open `jpfelgueiras/btc-timesfm`.
-2. Go to **Settings -> Secrets and variables -> Actions**.
-3. Select **New repository secret**.
-4. Name it `X_COOKIES_JSON`.
-5. Paste the complete JSON object as the value.
-
-After the secret is stored, remove the temporary local file:
-
-```bash
 rm x_cookies.json
 ```
 
-Once Twikit posting has been tested successfully, the four old X API OAuth secrets can be deleted because this branch no longer reads them.
-
-### 3. Test the session
-
-Run **BTC TimesFM 3 Forecast** manually from GitHub Actions on `feature/x-forecast-reliability` with `post_to_x` enabled.
-
-A successful post writes an `x_post_status.json` similar to:
-
-```json
-{
-  "status": "posted",
-  "provider": "twikit",
-  "post_id": "1234567890"
-}
-```
-
-If the session expires, is revoked, or X blocks the request, refresh `auth_token` and `ct0` from a logged-in browser session and replace the `X_COOKIES_JSON` secret.
+Treat these cookies like a password and never commit them.
 
 ## Forecast state
 
-The current `forecast.json` is copied to `.state/previous_forecast.json` and saved with `actions/cache/save`. The next workflow run restores the most recent matching cache entry.
+`.state/previous_forecast.json` now stores a versioned rolling forecast history rather than only one previous run. Keeping the existing path allows the first multi-horizon run to import the previous single-forecast cache automatically.
 
-This avoids committing generated forecast state back to the repository.
+The state is saved with `actions/cache/save`, so generated forecast history is not committed to the repository.
 
 ## Data source
 
@@ -178,7 +134,11 @@ python post_to_x.py
 
 ## Output
 
-`forecast.json` contains the current forecast plus a `previous_forecast_reliability` section when a comparable previous forecast is available.
+`forecast.json` contains:
+
+- the current 2h/4h/8h/16h forecasts
+- `forecast_reliability` with the latest matured score for each available horizon
+- `previous_forecast_reliability` as a backwards-compatible alias for the 2h score
 
 The JSON, generated X post and `x_post_status.json` are shown or uploaded by GitHub Actions as appropriate, with artifacts retained for 7 days.
 

--- a/btc_forecast.py
+++ b/btc_forecast.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Forecast BTC/USD with TimesFM 3 and score the previous +2h prediction."""
+"""Forecast BTC/USD with TimesFM 3 and score matured multi-horizon predictions."""
 
 from __future__ import annotations
 
@@ -21,11 +21,12 @@ INTERVAL_MINUTES = 60
 CONTEXT_POINTS = 512
 FORECAST_HOURS = 16
 TARGET_HOURS = (2, 4, 8, 16)
+HISTORY_LIMIT = 48
 
 MODEL_ID = "google/timesfm-3.0-pytorch"
 OUTPUT_PATH = Path("forecast.json")
 TWEET_PATH = Path("tweet.txt")
-PREVIOUS_FORECAST_PATH = Path(".state/previous_forecast.json")
+STATE_PATH = Path(".state/previous_forecast.json")
 
 
 def get_completed_hourly_candles() -> tuple[np.ndarray, list[int]]:
@@ -70,47 +71,50 @@ def load_model() -> TimesFM3Evaluator:
     return TimesFM3Evaluator(config)
 
 
-def load_previous_forecast() -> dict[str, Any] | None:
-    if not PREVIOUS_FORECAST_PATH.exists():
-        return None
+def load_forecast_history() -> list[dict[str, Any]]:
+    """Load forecast history, including the legacy single-forecast state format."""
+    if not STATE_PATH.exists():
+        return []
 
     try:
-        return json.loads(PREVIOUS_FORECAST_PATH.read_text())
+        state = json.loads(STATE_PATH.read_text())
     except (json.JSONDecodeError, OSError) as exc:
-        print(f"Ignoring unreadable previous forecast state: {exc}")
-        return None
+        print(f"Ignoring unreadable forecast state: {exc}")
+        return []
+
+    if isinstance(state, dict) and isinstance(state.get("forecasts"), list):
+        return [item for item in state["forecasts"] if isinstance(item, dict)]
+
+    # Backwards compatibility with the old cache, which stored one forecast directly.
+    if isinstance(state, dict) and "predictions" in state:
+        return [state]
+
+    print("Ignoring incompatible forecast state format")
+    return []
 
 
-def score_previous_forecast(
-    previous: dict[str, Any] | None,
-    closes: np.ndarray,
-    close_timestamps: list[int],
+def score_prediction(
+    forecast_snapshot: dict[str, Any],
+    hour: int,
+    actual_by_timestamp: dict[int, float],
 ) -> dict[str, Any] | None:
-    """Score the previous run's +2h forecast against the matching actual close."""
-    if not previous:
-        return None
-
     try:
-        previous_close = float(previous["latest_close_usd"])
-        previous_close_at = datetime.fromisoformat(previous["latest_close_at"])
-        prediction = previous["predictions"]["2h"]
+        previous_close = float(forecast_snapshot["latest_close_usd"])
+        previous_close_at = datetime.fromisoformat(forecast_snapshot["latest_close_at"])
+        prediction = forecast_snapshot["predictions"][f"{hour}h"]
         predicted_price = float(prediction["price_usd"])
         q10 = float(prediction["q10_usd"])
         q90 = float(prediction["q90_usd"])
-    except (KeyError, TypeError, ValueError) as exc:
-        print(f"Previous forecast has an incompatible format: {exc}")
+    except (KeyError, TypeError, ValueError):
         return None
 
     if previous_close_at.tzinfo is None:
         previous_close_at = previous_close_at.replace(tzinfo=timezone.utc)
 
-    target_at = previous_close_at.astimezone(timezone.utc) + timedelta(hours=2)
-    target_timestamp = int(target_at.timestamp())
-    actual_by_timestamp = dict(zip(close_timestamps, map(float, closes), strict=True))
-    actual_price = actual_by_timestamp.get(target_timestamp)
-
+    origin_at = previous_close_at.astimezone(timezone.utc)
+    target_at = origin_at + timedelta(hours=hour)
+    actual_price = actual_by_timestamp.get(int(target_at.timestamp()))
     if actual_price is None:
-        print(f"No completed candle found for previous +2h target {target_at.isoformat()}")
         return None
 
     absolute_error_usd = abs(predicted_price - actual_price)
@@ -125,13 +129,9 @@ def score_previous_forecast(
             return -1
         return 0
 
-    direction_correct = direction(predicted_price - previous_close) == direction(
-        actual_price - previous_close
-    )
-    within_interval = q10 <= actual_price <= q90
-
     return {
-        "horizon": "2h",
+        "horizon": f"{hour}h",
+        "forecast_origin_at": origin_at.isoformat(),
         "target_at": target_at.isoformat(),
         "predicted_price_usd": round(predicted_price, 2),
         "actual_price_usd": round(actual_price, 2),
@@ -139,9 +139,53 @@ def score_previous_forecast(
         "absolute_error_pct": round(absolute_error_pct, 4),
         "predicted_change_pct": round(predicted_change_pct, 4),
         "actual_change_pct": round(actual_change_pct, 4),
-        "direction_correct": direction_correct,
-        "within_q10_q90": within_interval,
+        "direction_correct": direction(predicted_price - previous_close)
+        == direction(actual_price - previous_close),
+        "within_q10_q90": q10 <= actual_price <= q90,
     }
+
+
+def score_forecast_history(
+    history: list[dict[str, Any]],
+    closes: np.ndarray,
+    close_timestamps: list[int],
+) -> dict[str, dict[str, Any]]:
+    """Score the most recent matured forecast for each configured horizon."""
+    actual_by_timestamp = dict(zip(close_timestamps, map(float, closes), strict=True))
+    reliability: dict[str, dict[str, Any]] = {}
+
+    for hour in TARGET_HOURS:
+        for snapshot in reversed(history):
+            score = score_prediction(snapshot, hour, actual_by_timestamp)
+            if score is not None:
+                reliability[f"{hour}h"] = score
+                break
+
+    return reliability
+
+
+def save_forecast_history(history: list[dict[str, Any]], output: dict[str, Any]) -> None:
+    """Persist compact forecast snapshots for future 2h/4h/8h/16h scoring."""
+    snapshot = {
+        "generated_at": output["generated_at"],
+        "latest_close_at": output["latest_close_at"],
+        "latest_close_usd": output["latest_close_usd"],
+        "predictions": output["predictions"],
+    }
+
+    # Replace any forecast for the same source candle, which can happen with manual reruns.
+    deduplicated = [
+        item
+        for item in history
+        if item.get("latest_close_at") != snapshot["latest_close_at"]
+    ]
+    deduplicated.append(snapshot)
+    deduplicated = deduplicated[-HISTORY_LIMIT:]
+
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    STATE_PATH.write_text(
+        json.dumps({"version": 2, "forecasts": deduplicated}, indent=2) + "\n"
+    )
 
 
 def format_price(value: float) -> str:
@@ -150,6 +194,8 @@ def format_price(value: float) -> str:
 
 def build_tweet(output: dict[str, Any]) -> str:
     predictions = output["predictions"]
+    reliability = output.get("forecast_reliability", {})
+
     lines = [
         "BTC/USD - TimesFM 3",
         f"Now {format_price(output['latest_close_usd'])}",
@@ -163,32 +209,47 @@ def build_tweet(output: dict[str, Any]) -> str:
         ),
     ]
 
-    reliability = output.get("previous_forecast_reliability")
-    if reliability:
-        direction_mark = "OK" if reliability["direction_correct"] else "MISS"
-        range_mark = "in range" if reliability["within_q10_q90"] else "out of range"
-        lines.append(
-            f"Prev +2h: {reliability['absolute_error_pct']:.2f}% error | "
-            f"direction {direction_mark} | {range_mark}"
+    error_parts = []
+    for horizon in ("2h", "4h", "8h", "16h"):
+        score = reliability.get(horizon)
+        error_parts.append(
+            f"{horizon} {score['absolute_error_pct']:.2f}%" if score else f"{horizon} --"
         )
-    else:
-        lines.append("Prev +2h: no comparable prior forecast yet")
-
+    lines.append("Prev err: " + " | ".join(error_parts))
     lines.append("Experimental - not financial advice.")
+
     tweet = "\n".join(lines)
-
-    # Keep a little buffer below X's 280-character limit.
-    if len(tweet) > 270 and reliability:
-        lines[-2] = (
-            f"Prev +2h: {reliability['absolute_error_pct']:.2f}% err | "
-            f"dir {'OK' if reliability['direction_correct'] else 'MISS'}"
-        )
-        tweet = "\n".join(lines)
-
     if len(tweet) > 280:
         raise RuntimeError(f"Generated X post is too long: {len(tweet)} characters")
-
     return tweet
+
+
+def print_reliability(reliability: dict[str, dict[str, Any]]) -> None:
+    print("\nPrevious forecast comparison")
+    print("-" * 96)
+    print(
+        f"{'Horizon':<9}{'Predicted':>14}{'Actual':>14}{'Error':>11}"
+        f"{'Direction':>13}{'Q10-Q90':>12}{'Forecast origin':>23}"
+    )
+    print("-" * 96)
+
+    for hour in TARGET_HOURS:
+        horizon = f"{hour}h"
+        score = reliability.get(horizon)
+        if not score:
+            print(f"+{horizon:<8}{'not enough history yet':>34}")
+            continue
+
+        origin = datetime.fromisoformat(score["forecast_origin_at"]).strftime("%Y-%m-%d %H:%M")
+        print(
+            f"+{horizon:<8}"
+            f"${score['predicted_price_usd']:>12,.2f}"
+            f"${score['actual_price_usd']:>12,.2f}"
+            f"{score['absolute_error_pct']:>10.3f}%"
+            f"{'correct' if score['direction_correct'] else 'wrong':>13}"
+            f"{'inside' if score['within_q10_q90'] else 'outside':>12}"
+            f"{origin:>23}"
+        )
 
 
 def main() -> None:
@@ -199,8 +260,8 @@ def main() -> None:
     print(f"Loaded {len(closes)} completed hourly candles")
     print(f"Latest BTC/USD close: ${current_price:,.2f} at {latest_close_at.isoformat()}")
 
-    previous = load_previous_forecast()
-    previous_reliability = score_previous_forecast(previous, closes, close_timestamps)
+    history = load_forecast_history()
+    reliability = score_forecast_history(history, closes, close_timestamps)
 
     model = load_model()
     outputs = list(
@@ -241,10 +302,14 @@ def main() -> None:
         "latest_close_at": latest_close_at.isoformat(),
         "latest_close_usd": round(current_price, 2),
         "predictions": predictions,
-        "previous_forecast_reliability": previous_reliability,
+        "forecast_reliability": reliability,
+        # Preserve the old field for consumers that still expect the +2h score.
+        "previous_forecast_reliability": reliability.get("2h"),
     }
 
     OUTPUT_PATH.write_text(json.dumps(output, indent=2) + "\n")
+    save_forecast_history(history, output)
+
     tweet = build_tweet(output)
     TWEET_PATH.write_text(tweet + "\n")
 
@@ -262,17 +327,10 @@ def main() -> None:
             f"${prediction['q90_usd']:>14,.2f}"
         )
 
-    if previous_reliability:
-        print(
-            "\nPrevious +2h forecast: "
-            f"{previous_reliability['absolute_error_pct']:.3f}% absolute error; "
-            f"direction {'correct' if previous_reliability['direction_correct'] else 'wrong'}; "
-            f"actual {'inside' if previous_reliability['within_q10_q90'] else 'outside'} Q10-Q90"
-        )
-    else:
-        print("\nNo previous +2h forecast available to score yet.")
+    print_reliability(reliability)
 
     print(f"\nSaved forecast to {OUTPUT_PATH}")
+    print(f"Saved forecast history to {STATE_PATH} ({min(len(history) + 1, HISTORY_LIMIT)} snapshots max)")
     print(f"Saved X post to {TWEET_PATH}:\n\n{tweet}")
 
 


### PR DESCRIPTION
## Summary
- compare matured +2h, +4h, +8h and +16h forecasts against the matching Kraken closes
- report absolute USD/% error, predicted vs actual change, direction accuracy and Q10-Q90 containment per horizon
- keep a rolling forecast history so longer horizons can be evaluated once they mature
- include compact multi-horizon reliability results in the generated X post
- keep compatibility with the previous single-forecast cache format

## Notes
- +4h, +8h and +16h reliability results appear only after enough scheduled history has accumulated
- the workflow continues to run every 2 hours and uses the same X posting setup

## Files changed
- `btc_forecast.py`
- `.github/workflows/forecast.yml`
- `README.md`