### PR TITLE
Improve BTC forecasting with ensembles and backtesting

### DIFF
--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -1,0 +1,63 @@
+name: BTC Forecast Backtest
+
+on:
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Historical days to download"
+        required: false
+        default: "90"
+        type: string
+      samples:
+        description: "Walk-forward forecast samples"
+        required: false
+        default: "60"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  backtest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Cache Hugging Face model
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: timesfm-3-${{ runner.os }}-v1
+          restore-keys: |
+            timesfm-3-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run walk-forward backtest
+        run: python backtest.py --days "${{ inputs.days }}" --samples "${{ inputs.samples }}"
+
+      - name: Add report to summary
+        run: |
+          echo '## BTC forecast backtest' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat backtest_report.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: btc-backtest-${{ github.run_id }}
+          path: backtest_report.json
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -1,120 +1,130 @@
-# BTC TimesFM 3 Forecast
+# BTC Forecast Ensemble
 
-A small experiment using Google's **TimesFM 3** to forecast BTC/USD from completed hourly candles.
+A BTC/USD forecasting experiment built around **TimesFM 3**, Kraken hourly candles, multiple baselines, regime detection, calibrated uncertainty and walk-forward backtesting.
+
+## What changed
+
+The production forecast no longer feeds raw BTC prices into one TimesFM context. It now:
+
+- forecasts **hourly log returns** and reconstructs future prices
+- runs TimesFM with **168h, 336h and 512h** context windows
+- compares/ensembles TimesFM with **persistence, 7-day drift and AR(1)** baselines
+- changes ensemble weights for **range, trending and high-volatility** regimes
+- derives market context from volatility, volume, high-low range, RSI, momentum and time-of-day/day-of-week
+- reports **model agreement** as an additional confidence signal
+- calibrates the Q10-Q90 interval from recent empirical coverage once enough samples exist
+- evaluates 2h, 4h, 8h and 16h forecasts against the exact matching Kraken close
+- tracks MAE, signed bias, direction accuracy and interval coverage
+- stores per-model predictions so TimesFM can be compared directly with the simple baselines
+- includes a separate walk-forward backtesting workflow
+
+A second foundation model is intentionally not part of the scheduled ensemble yet: loading another large checkpoint every run would substantially increase GitHub Actions runtime. The architecture now makes it straightforward to add one later if backtests show it is worth the extra compute.
 
 ## Forecast horizons
 
-Every forecast produces:
+Every production run forecasts +2h, +4h, +8h and +16h. The main `predictions` block is the ensemble result. `model_predictions` contains each underlying model/context separately.
 
-- +2 hours
-- +4 hours
-- +8 hours
-- +16 hours
+## Why forecast returns instead of raw price?
 
-The output also includes TimesFM's 10th, 50th and 90th percentile estimates.
+The model receives hourly log returns:
+
+```text
+log(close[t] / close[t-1])
+```
+
+The predicted return path is accumulated and converted back into a BTC price. Returns are generally more stable than the raw BTC price level and make forecasts across different market-price regimes more comparable.
+
+## Multi-context TimesFM
+
+Each forecast uses three views of the market:
+
+```text
+168 hours   = 7 days
+336 hours   = 14 days
+512 hours   = ~21 days
+```
+
+The contexts are forecast independently and then combined. This reduces dependence on one arbitrary context length.
+
+## Baselines
+
+The ensemble also contains:
+
+- `persistence`: future BTC = current BTC
+- `drift_7d`: extrapolates the mean 7-day log return, with volatility clipping
+- `ar1`: a simple autoregressive forecast of hourly log returns
+
+These are deliberately simple. If TimesFM cannot consistently beat persistence in the backtest, the more complex forecast is not adding much useful signal.
+
+## Market features and regime detection
+
+Each run records 6h/24h/7d realized volatility, average high-low range, volume z-score, RSI(14), 6h/24h/7d momentum and cyclic hour/day features.
+
+Those features classify the market as `range`, `trending` or `high_volatility`. The regime changes the relative weights of TimesFM, persistence, drift and AR(1), and the features are saved for later analysis.
+
+## Confidence and uncertainty
+
+For each horizon the output includes the ensemble price, change from current price, Q10/Q50/Q90 interval, model agreement, interval calibration multiplier and empirical Q10-Q90 coverage once enough history exists.
+
+The TimesFM quantile paths provide the starting uncertainty band. The band is widened when the models disagree and, after at least 10 matured samples, adjusted toward approximately 80% empirical Q10-Q90 coverage.
+
+## Reliability metrics
+
+The rolling history stores up to 72 snapshots. Matured predictions are matched to the exact Kraken hourly close at their target timestamp.
+
+For each horizon the project tracks absolute USD error, MAE %, signed error/bias, predicted vs actual change, direction accuracy, Q10-Q90 coverage and per-model performance. `forecast.json` also includes an aggregate `performance_summary` from the history currently available.
 
 ## Schedule
 
-GitHub Actions wakes up every hour at minute `37` UTC:
+GitHub Actions wakes up hourly at minute `37` UTC:
 
-```text
-00:37
-01:37
-02:37
-...
-23:37
+```yaml
+schedule:
+  - cron: "37 * * * *"
 ```
 
-The hourly trigger is intentional. GitHub's scheduled workflows are best-effort and can be delayed or occasionally dropped, so the workflow restores the latest forecast history first and runs the expensive TimesFM forecast only when at least **two completed hourly candles** have elapsed since the last saved forecast.
+A lightweight guard restores forecast state first. The expensive forecast only runs after at least two completed candle-hours have elapsed since the previous saved forecast. This gives GitHub another opportunity every hour if a scheduled event is delayed or dropped while still producing roughly one forecast every two hours.
 
-In the normal case this still produces one forecast roughly every 2 hours. If GitHub misses one cron event, the next hourly trigger can recover instead of waiting for the next fixed 2-hour slot.
+Scheduled forecasts post to X automatically. Manual runs only post when `post_to_x=true`.
 
-Skipped hourly checks do not install the model dependencies, restore the large Hugging Face model cache, post to X, or create a forecast artifact. Manual `workflow_dispatch` runs always execute and can optionally post by enabling the `post_to_x` input.
+## X posting
 
-## Multi-horizon forecast reliability
-
-The workflow keeps a rolling history of recent forecasts and scores the most recent matured prediction for each horizon: **2h, 4h, 8h and 16h**.
-
-For example, at a 12:00 run:
-
-- the 2h comparison comes from the forecast issued around 10:00
-- the 4h comparison comes from the forecast issued around 08:00
-- the 8h comparison comes from the forecast issued around 04:00
-- the 16h comparison comes from the forecast issued around 20:00 the previous day
-
-Each score is matched to the exact completed Kraken hourly candle at that prediction's target timestamp. The reliability block records:
-
-- predicted and actual price
-- absolute price error in USD
-- absolute percentage error
-- predicted vs actual percentage change
-- whether the predicted direction was correct
-- whether the actual price landed inside the forecast Q10-Q90 interval
-
-The forecast history keeps up to 48 snapshots and is persisted through the GitHub Actions cache. The old single-forecast cache format is migrated automatically on the first run.
-
-A fresh history needs time to mature: 2h accuracy appears first, then 4h, 8h and finally 16h after enough scheduled runs have accumulated.
-
-## X / Twitter posting with Twikit
-
-The workflow generates a `tweet.txt` file with current forecasts plus the latest available error for each horizon, for example:
+Posting uses Twikit with the `X_COOKIES_JSON` repository secret. Example:
 
 ```text
-BTC/USD - TimesFM 3
-Now $100,000
+BTC/USD ensemble forecast
+Now $100,000 | trending
 2h $100,200 (+0.20%) | 4h $100,450 (+0.45%)
 8h $100,800 (+0.80%) | 16h $101,100 (+1.10%)
 Prev err: 2h 0.31% | 4h 0.42% | 8h 0.75% | 16h 1.10%
 Experimental - not financial advice.
 ```
 
-Posting uses **Twikit 2.3.3** and an authenticated X web-session cookie. It does **not** use X's paid developer API.
+Twikit is an unofficial X client and can break when X changes its internal frontend/API behavior.
 
-Twikit is an unofficial X/Twitter client. It can break when X changes its internal endpoints, and X may reject activity that looks automated. Reuse the same session, keep the posting rate modest, and refresh the browser session cookie if X invalidates it.
+## Backtesting
 
-### X session cookies
+`backtest.py` performs walk-forward historical forecasts and compares the ensemble against every underlying model.
 
-Open `https://x.com` in a desktop browser where you are logged in and copy the `auth_token` and `ct0` cookies from the browser developer tools.
+The manual **BTC Forecast Backtest** GitHub workflow defaults to 90 days of history and 60 walk-forward samples.
 
-Create a temporary local file:
+Historical backtesting uses Binance BTCUSDT hourly candles because Kraken's public OHLC endpoint does not expose enough older hourly candles for a multi-month walk-forward test. Production forecasting still uses Kraken BTC/USD.
 
-```json
-{
-  "auth_token": "YOUR_AUTH_TOKEN",
-  "ct0": "YOUR_CT0"
-}
-```
-
-Store it as the repository secret:
+Run locally:
 
 ```bash
-gh secret set X_COOKIES_JSON --repo jpfelgueiras/btc-timesfm < x_cookies.json
-rm x_cookies.json
+python backtest.py --days 90 --samples 60
 ```
 
-Treat these cookies like a password and never commit them.
+The result is written to `backtest_report.json` with MAE %, mean signed error, direction accuracy, ensemble interval coverage and ensemble performance by regime.
 
-## Forecast state
+The most important comparison is whether the ensemble and the individual TimesFM contexts beat `persistence` consistently.
 
-`.state/previous_forecast.json` stores a versioned rolling forecast history. The scheduler guard reads the most recent `latest_close_at` from this state before deciding whether a scheduled forecast is due.
+## Production output
 
-The state is saved with `actions/cache/save`, so generated forecast history is not committed to the repository.
+`forecast.json` contains the latest BTC/USD close, market features, regime, model weights, per-model forecasts, ensemble 2h/4h/8h/16h forecasts, model agreement, calibrated uncertainty, latest matured reliability and rolling performance summary.
 
-## Data source
-
-Kraken's public BTC/USD hourly OHLC endpoint is used, so no exchange API key is required.
-
-Only completed candles are passed to the model.
-
-## Model
-
-```text
-google/timesfm-3.0-pytorch
-```
-
-The project uses `timesfm[torch]==3.0.1` and runs inference on CPU so it works on a standard GitHub-hosted Ubuntu runner.
-
-The Hugging Face model directory is cached between forecast runs.
+Forecast history lives in `.state/previous_forecast.json` and is persisted with the GitHub Actions cache rather than committed to the repository.
 
 ## Run locally
 
@@ -127,27 +137,15 @@ pip install -r requirements.txt
 python btc_forecast.py
 ```
 
-The first run downloads the TimesFM 3 checkpoint.
-
-To post the generated `tweet.txt` locally with a temporary cookie file:
+To post the generated `tweet.txt` locally:
 
 ```bash
 export X_COOKIES_JSON="$(cat x_cookies.json)"
 python post_to_x.py
 ```
 
-## Output
-
-`forecast.json` contains:
-
-- the current 2h/4h/8h/16h forecasts
-- `forecast_reliability` with the latest matured score for each available horizon
-- `previous_forecast_reliability` as a backwards-compatible alias for the 2h score
-
-The JSON, generated X post and `x_post_status.json` are shown or uploaded by GitHub Actions as appropriate, with artifacts retained for 7 days.
-
 ## Important
 
-This is a forecasting experiment, not a trading signal.
+This is an experiment, not a trading signal or financial advice. Backtesting is required before interpreting direction accuracy or forecast errors as useful predictive skill.
 
-TimesFM 3 pretrained weights currently have a separate non-commercial/non-production license. Check the model license before using it for real-money or production trading.
+TimesFM 3 pretrained weights have their own license terms; verify the model license before production or commercial use.

--- a/backtest.py
+++ b/backtest.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Walk-forward backtest for the BTC forecast ensemble.
+
+Historical candles come from Binance BTCUSDT because Kraken's OHLC endpoint only
+exposes a limited recent window. BTCUSDT is used as a liquid USD proxy for
+research/backtesting; production forecasts continue to use Kraken BTC/USD.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import requests
+
+from forecast_engine import MarketData, TARGET_HOURS, build_forecast, load_timesfm
+
+
+BINANCE_KLINES = "https://api.binance.com/api/v3/klines"
+REPORT_PATH = Path("backtest_report.json")
+
+
+def fetch_binance_history(days: int) -> MarketData:
+    end_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    start_ms = int((datetime.now(timezone.utc) - timedelta(days=days)).timestamp() * 1000)
+    rows: list[list[Any]] = []
+    cursor = start_ms
+
+    while cursor < end_ms:
+        response = requests.get(
+            BINANCE_KLINES,
+            params={
+                "symbol": "BTCUSDT",
+                "interval": "1h",
+                "startTime": cursor,
+                "endTime": end_ms,
+                "limit": 1000,
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        batch = response.json()
+        if not batch:
+            break
+        rows.extend(batch)
+        next_cursor = int(batch[-1][0]) + 3600_000
+        if next_cursor <= cursor:
+            break
+        cursor = next_cursor
+        time.sleep(0.05)
+
+    if len(rows) < 550:
+        raise RuntimeError(f"Not enough historical candles: {len(rows)}")
+
+    # Binance timestamps are candle open times; convert to completed-candle time.
+    timestamps = [int(row[0] / 1000) + 3600 for row in rows]
+    return MarketData(
+        timestamps=timestamps,
+        opens=np.asarray([float(row[1]) for row in rows], dtype=np.float32),
+        highs=np.asarray([float(row[2]) for row in rows], dtype=np.float32),
+        lows=np.asarray([float(row[3]) for row in rows], dtype=np.float32),
+        closes=np.asarray([float(row[4]) for row in rows], dtype=np.float32),
+        volumes=np.asarray([float(row[5]) for row in rows], dtype=np.float32),
+    )
+
+
+def slice_market(data: MarketData, end_index: int, context: int = 513) -> MarketData:
+    start = max(0, end_index - context + 1)
+    sl = slice(start, end_index + 1)
+    return MarketData(
+        timestamps=data.timestamps[start : end_index + 1],
+        opens=data.opens[sl],
+        highs=data.highs[sl],
+        lows=data.lows[sl],
+        closes=data.closes[sl],
+        volumes=data.volumes[sl],
+    )
+
+
+def direction(value: float, epsilon: float = 1e-9) -> int:
+    return 1 if value > epsilon else -1 if value < -epsilon else 0
+
+
+def score_one(current: float, predicted: float, actual: float) -> dict[str, Any]:
+    error = predicted - actual
+    return {
+        "absolute_error_pct": abs(error) / actual * 100.0,
+        "signed_error_pct": error / actual * 100.0,
+        "direction_correct": direction(predicted - current) == direction(actual - current),
+    }
+
+
+def summarize(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for horizon in ("2h", "4h", "8h", "16h"):
+        per_model: dict[str, list[dict[str, Any]]] = {}
+        ensemble_coverage: list[bool] = []
+        regime_scores: dict[str, list[dict[str, Any]]] = {}
+
+        for sample in samples:
+            actual = sample["actuals"][horizon]
+            current = sample["current_price"]
+            ensemble = sample["forecast"]["predictions"][horizon]
+            score = score_one(current, ensemble["price_usd"], actual)
+            per_model.setdefault("ensemble", []).append(score)
+            ensemble_coverage.append(ensemble["q10_usd"] <= actual <= ensemble["q90_usd"])
+            regime_scores.setdefault(sample["forecast"]["regime"], []).append(score)
+
+            for name, horizons in sample["forecast"]["model_predictions"].items():
+                per_model.setdefault(name, []).append(
+                    score_one(current, horizons[horizon]["price_usd"], actual)
+                )
+
+        models: dict[str, Any] = {}
+        for name, scores in sorted(per_model.items()):
+            models[name] = {
+                "samples": len(scores),
+                "mae_pct": round(float(np.mean([s["absolute_error_pct"] for s in scores])), 4),
+                "mean_signed_error_pct": round(float(np.mean([s["signed_error_pct"] for s in scores])), 4),
+                "direction_accuracy": round(float(np.mean([s["direction_correct"] for s in scores])), 4),
+            }
+            if name == "ensemble":
+                models[name]["q10_q90_coverage"] = round(float(np.mean(ensemble_coverage)), 4)
+
+        by_regime = {
+            regime: {
+                "samples": len(scores),
+                "mae_pct": round(float(np.mean([s["absolute_error_pct"] for s in scores])), 4),
+                "direction_accuracy": round(float(np.mean([s["direction_correct"] for s in scores])), 4),
+            }
+            for regime, scores in sorted(regime_scores.items())
+        }
+        result[horizon] = {"models": models, "ensemble_by_regime": by_regime}
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--days", type=int, default=90)
+    parser.add_argument("--samples", type=int, default=60)
+    args = parser.parse_args()
+
+    data = fetch_binance_history(args.days)
+    first = 513
+    last = len(data.closes) - max(TARGET_HOURS) - 1
+    if last <= first:
+        raise RuntimeError("Historical window is too small for the requested backtest")
+
+    candidate_indices = np.linspace(first, last, num=min(args.samples, last - first + 1), dtype=int)
+    indices = sorted(set(map(int, candidate_indices)))
+    model = load_timesfm()
+    samples: list[dict[str, Any]] = []
+
+    for number, index in enumerate(indices, start=1):
+        context = slice_market(data, index)
+        forecast = build_forecast(model, context, history=[])
+        actuals = {
+            f"{hour}h": float(data.closes[index + hour])
+            for hour in TARGET_HOURS
+        }
+        samples.append(
+            {
+                "origin_at": datetime.fromtimestamp(data.timestamps[index], tz=timezone.utc).isoformat(),
+                "current_price": float(data.closes[index]),
+                "actuals": actuals,
+                "forecast": forecast,
+            }
+        )
+        print(f"Backtest {number}/{len(indices)}: {samples[-1]['origin_at']} ({forecast['regime']})")
+
+    report = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "data_source": "Binance BTCUSDT 1h (historical proxy for BTC/USD)",
+        "days_requested": args.days,
+        "samples": len(samples),
+        "summary": summarize(samples),
+    }
+    REPORT_PATH.write_text(json.dumps(report, indent=2) + "\n")
+
+    print("\nBacktest summary")
+    for horizon, info in report["summary"].items():
+        ensemble = info["models"]["ensemble"]
+        persistence = info["models"].get("persistence", {})
+        print(
+            f"{horizon}: ensemble MAE {ensemble['mae_pct']:.3f}% / dir "
+            f"{ensemble['direction_accuracy']:.1%}; persistence MAE "
+            f"{persistence.get('mae_pct', float('nan')):.3f}%"
+        )
+    print(f"\nSaved {REPORT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/btc_forecast.py
+++ b/btc_forecast.py
@@ -1,81 +1,27 @@
 #!/usr/bin/env python3
-"""Forecast BTC/USD with TimesFM 3 and score matured multi-horizon predictions."""
+"""Forecast BTC/USD and evaluate matured multi-model predictions."""
 
 from __future__ import annotations
 
 import json
-import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
 import numpy as np
-import requests
-from timesfm3 import ModelConfig, TimesFM3Evaluator
+
+from forecast_engine import TARGET_HOURS, build_forecast, fetch_kraken_hourly, load_timesfm
 
 
-KRAKEN_OHLC_URL = "https://api.kraken.com/0/public/OHLC"
-PAIR = "XBTUSD"
-INTERVAL_MINUTES = 60
-
-CONTEXT_POINTS = 512
-FORECAST_HOURS = 16
-TARGET_HOURS = (2, 4, 8, 16)
-HISTORY_LIMIT = 48
-
-MODEL_ID = "google/timesfm-3.0-pytorch"
 OUTPUT_PATH = Path("forecast.json")
 TWEET_PATH = Path("tweet.txt")
 STATE_PATH = Path(".state/previous_forecast.json")
-
-
-def get_completed_hourly_candles() -> tuple[np.ndarray, list[int]]:
-    response = requests.get(
-        KRAKEN_OHLC_URL,
-        params={"pair": PAIR, "interval": INTERVAL_MINUTES},
-        timeout=30,
-    )
-    response.raise_for_status()
-    payload = response.json()
-
-    if payload.get("error"):
-        raise RuntimeError(f"Kraken API error: {payload['error']}")
-
-    result = payload["result"]
-    pair_key = next(key for key in result if key != "last")
-    candles = result[pair_key]
-
-    now = time.time()
-    completed = [
-        candle
-        for candle in candles
-        if float(candle[0]) + INTERVAL_MINUTES * 60 <= now
-    ]
-
-    if len(completed) < 64:
-        raise RuntimeError(f"Not enough completed candles: {len(completed)}")
-
-    completed = completed[-CONTEXT_POINTS:]
-    closes = np.asarray([float(candle[4]) for candle in completed], dtype=np.float32)
-    close_timestamps = [int(float(candle[0])) + INTERVAL_MINUTES * 60 for candle in completed]
-    return closes, close_timestamps
-
-
-def load_model() -> TimesFM3Evaluator:
-    print(f"Loading {MODEL_ID} on CPU...")
-    config = ModelConfig(
-        checkpoint_path=MODEL_ID,
-        per_core_batch_size=1,
-        device="cpu",
-    )
-    return TimesFM3Evaluator(config)
+HISTORY_LIMIT = 72
 
 
 def load_forecast_history() -> list[dict[str, Any]]:
-    """Load forecast history, including the legacy single-forecast state format."""
     if not STATE_PATH.exists():
         return []
-
     try:
         state = json.loads(STATE_PATH.read_text())
     except (json.JSONDecodeError, OSError) as exc:
@@ -84,107 +30,175 @@ def load_forecast_history() -> list[dict[str, Any]]:
 
     if isinstance(state, dict) and isinstance(state.get("forecasts"), list):
         return [item for item in state["forecasts"] if isinstance(item, dict)]
-
-    # Backwards compatibility with the old cache, which stored one forecast directly.
     if isinstance(state, dict) and "predictions" in state:
         return [state]
-
-    print("Ignoring incompatible forecast state format")
     return []
 
 
-def score_prediction(
-    forecast_snapshot: dict[str, Any],
-    hour: int,
-    actual_by_timestamp: dict[int, float],
-) -> dict[str, Any] | None:
-    try:
-        previous_close = float(forecast_snapshot["latest_close_usd"])
-        previous_close_at = datetime.fromisoformat(forecast_snapshot["latest_close_at"])
-        prediction = forecast_snapshot["predictions"][f"{hour}h"]
-        predicted_price = float(prediction["price_usd"])
-        q10 = float(prediction["q10_usd"])
-        q90 = float(prediction["q90_usd"])
-    except (KeyError, TypeError, ValueError):
-        return None
+def _direction(value: float, epsilon: float = 1e-9) -> int:
+    return 1 if value > epsilon else -1 if value < -epsilon else 0
 
-    if previous_close_at.tzinfo is None:
-        previous_close_at = previous_close_at.replace(tzinfo=timezone.utc)
 
-    origin_at = previous_close_at.astimezone(timezone.utc)
-    target_at = origin_at + timedelta(hours=hour)
-    actual_price = actual_by_timestamp.get(int(target_at.timestamp()))
-    if actual_price is None:
-        return None
-
-    absolute_error_usd = abs(predicted_price - actual_price)
+def score_price(
+    previous_close: float,
+    predicted_price: float,
+    actual_price: float,
+    q10: float | None = None,
+    q90: float | None = None,
+) -> dict[str, Any]:
+    error = predicted_price - actual_price
+    absolute_error_usd = abs(error)
     absolute_error_pct = absolute_error_usd / actual_price * 100.0
+    signed_error_pct = error / actual_price * 100.0
     predicted_change_pct = (predicted_price / previous_close - 1.0) * 100.0
     actual_change_pct = (actual_price / previous_close - 1.0) * 100.0
-
-    def direction(value: float, epsilon: float = 1e-9) -> int:
-        if value > epsilon:
-            return 1
-        if value < -epsilon:
-            return -1
-        return 0
-
     return {
-        "horizon": f"{hour}h",
-        "forecast_origin_at": origin_at.isoformat(),
-        "target_at": target_at.isoformat(),
         "predicted_price_usd": round(predicted_price, 2),
         "actual_price_usd": round(actual_price, 2),
         "absolute_error_usd": round(absolute_error_usd, 2),
         "absolute_error_pct": round(absolute_error_pct, 4),
+        "signed_error_pct": round(signed_error_pct, 4),
         "predicted_change_pct": round(predicted_change_pct, 4),
         "actual_change_pct": round(actual_change_pct, 4),
-        "direction_correct": direction(predicted_price - previous_close)
-        == direction(actual_price - previous_close),
-        "within_q10_q90": q10 <= actual_price <= q90,
+        "direction_correct": _direction(predicted_price - previous_close)
+        == _direction(actual_price - previous_close),
+        "within_q10_q90": (
+            q10 <= actual_price <= q90 if q10 is not None and q90 is not None else None
+        ),
     }
+
+
+def score_snapshot(
+    snapshot: dict[str, Any],
+    hour: int,
+    actual_by_timestamp: dict[int, float],
+) -> dict[str, Any] | None:
+    try:
+        previous_close = float(snapshot["latest_close_usd"])
+        origin = datetime.fromisoformat(snapshot["latest_close_at"])
+        ensemble = snapshot["predictions"][f"{hour}h"]
+    except (KeyError, TypeError, ValueError):
+        return None
+
+    if origin.tzinfo is None:
+        origin = origin.replace(tzinfo=timezone.utc)
+    origin = origin.astimezone(timezone.utc)
+    target_at = origin + timedelta(hours=hour)
+    actual = actual_by_timestamp.get(int(target_at.timestamp()))
+    if actual is None:
+        return None
+
+    score = score_price(
+        previous_close,
+        float(ensemble["price_usd"]),
+        actual,
+        float(ensemble["q10_usd"]) if "q10_usd" in ensemble else None,
+        float(ensemble["q90_usd"]) if "q90_usd" in ensemble else None,
+    )
+    score.update(
+        {
+            "horizon": f"{hour}h",
+            "forecast_origin_at": origin.isoformat(),
+            "target_at": target_at.isoformat(),
+            "regime": snapshot.get("regime"),
+        }
+    )
+
+    model_scores: dict[str, Any] = {}
+    for model_name, horizons in snapshot.get("model_predictions", {}).items():
+        try:
+            item = horizons[f"{hour}h"]
+            model_scores[model_name] = score_price(
+                previous_close,
+                float(item["price_usd"]),
+                actual,
+                float(item["q10_usd"]) if "q10_usd" in item else None,
+                float(item["q90_usd"]) if "q90_usd" in item else None,
+            )
+        except (KeyError, TypeError, ValueError):
+            continue
+    score["models"] = model_scores
+    return score
 
 
 def score_forecast_history(
     history: list[dict[str, Any]],
     closes: np.ndarray,
-    close_timestamps: list[int],
+    timestamps: list[int],
 ) -> dict[str, dict[str, Any]]:
-    """Score the most recent matured forecast for each configured horizon."""
-    actual_by_timestamp = dict(zip(close_timestamps, map(float, closes), strict=True))
+    actuals = dict(zip(timestamps, map(float, closes), strict=True))
     reliability: dict[str, dict[str, Any]] = {}
-
     for hour in TARGET_HOURS:
         for snapshot in reversed(history):
-            score = score_prediction(snapshot, hour, actual_by_timestamp)
+            score = score_snapshot(snapshot, hour, actuals)
             if score is not None:
                 reliability[f"{hour}h"] = score
                 break
-
     return reliability
 
 
+def performance_summary(
+    history: list[dict[str, Any]],
+    closes: np.ndarray,
+    timestamps: list[int],
+) -> dict[str, Any]:
+    actuals = dict(zip(timestamps, map(float, closes), strict=True))
+    result: dict[str, Any] = {}
+
+    for hour in TARGET_HOURS:
+        scores = [
+            score
+            for snapshot in history
+            if (score := score_snapshot(snapshot, hour, actuals)) is not None
+        ]
+        if not scores:
+            continue
+
+        mae = float(np.mean([s["absolute_error_pct"] for s in scores]))
+        bias = float(np.mean([s["signed_error_pct"] for s in scores]))
+        direction = float(np.mean([s["direction_correct"] for s in scores]))
+        covered = [s["within_q10_q90"] for s in scores if s["within_q10_q90"] is not None]
+        coverage = float(np.mean(covered)) if covered else None
+
+        model_names = sorted({name for score in scores for name in score.get("models", {})})
+        models: dict[str, Any] = {}
+        for name in model_names:
+            model_scores = [s["models"][name] for s in scores if name in s.get("models", {})]
+            models[name] = {
+                "samples": len(model_scores),
+                "mae_pct": round(float(np.mean([s["absolute_error_pct"] for s in model_scores])), 4),
+                "direction_accuracy": round(float(np.mean([s["direction_correct"] for s in model_scores])), 4),
+            }
+
+        result[f"{hour}h"] = {
+            "samples": len(scores),
+            "mae_pct": round(mae, 4),
+            "mean_signed_error_pct": round(bias, 4),
+            "direction_accuracy": round(direction, 4),
+            "q10_q90_coverage": round(coverage, 4) if coverage is not None else None,
+            "models": models,
+        }
+    return result
+
+
 def save_forecast_history(history: list[dict[str, Any]], output: dict[str, Any]) -> None:
-    """Persist compact forecast snapshots for future 2h/4h/8h/16h scoring."""
     snapshot = {
         "generated_at": output["generated_at"],
         "latest_close_at": output["latest_close_at"],
         "latest_close_usd": output["latest_close_usd"],
+        "regime": output["regime"],
+        "market_features": output["market_features"],
+        "model_weights": output["model_weights"],
+        "model_predictions": output["model_predictions"],
         "predictions": output["predictions"],
     }
-
-    # Replace any forecast for the same source candle, which can happen with manual reruns.
     deduplicated = [
-        item
-        for item in history
-        if item.get("latest_close_at") != snapshot["latest_close_at"]
+        item for item in history if item.get("latest_close_at") != snapshot["latest_close_at"]
     ]
     deduplicated.append(snapshot)
-    deduplicated = deduplicated[-HISTORY_LIMIT:]
-
     STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
     STATE_PATH.write_text(
-        json.dumps({"version": 2, "forecasts": deduplicated}, indent=2) + "\n"
+        json.dumps({"version": 3, "forecasts": deduplicated[-HISTORY_LIMIT:]}, indent=2) + "\n"
     )
 
 
@@ -195,10 +209,9 @@ def format_price(value: float) -> str:
 def build_tweet(output: dict[str, Any]) -> str:
     predictions = output["predictions"]
     reliability = output.get("forecast_reliability", {})
-
     lines = [
-        "BTC/USD - TimesFM 3",
-        f"Now {format_price(output['latest_close_usd'])}",
+        "BTC/USD ensemble forecast",
+        f"Now {format_price(output['latest_close_usd'])} | {output['regime'].replace('_', ' ')}",
         " | ".join(
             f"{h} {format_price(predictions[h]['price_usd'])} ({predictions[h]['change_pct']:+.2f}%)"
             for h in ("2h", "4h")
@@ -208,129 +221,90 @@ def build_tweet(output: dict[str, Any]) -> str:
             for h in ("8h", "16h")
         ),
     ]
-
-    error_parts = []
+    errors = []
     for horizon in ("2h", "4h", "8h", "16h"):
         score = reliability.get(horizon)
-        error_parts.append(
-            f"{horizon} {score['absolute_error_pct']:.2f}%" if score else f"{horizon} --"
-        )
-    lines.append("Prev err: " + " | ".join(error_parts))
+        errors.append(f"{horizon} {score['absolute_error_pct']:.2f}%" if score else f"{horizon} --")
+    lines.append("Prev err: " + " | ".join(errors))
     lines.append("Experimental - not financial advice.")
-
     tweet = "\n".join(lines)
+    if len(tweet) > 280:
+        lines[1] = f"Now {format_price(output['latest_close_usd'])}"
+        tweet = "\n".join(lines)
     if len(tweet) > 280:
         raise RuntimeError(f"Generated X post is too long: {len(tweet)} characters")
     return tweet
 
 
 def print_reliability(reliability: dict[str, dict[str, Any]]) -> None:
-    print("\nPrevious forecast comparison")
-    print("-" * 96)
-    print(
-        f"{'Horizon':<9}{'Predicted':>14}{'Actual':>14}{'Error':>11}"
-        f"{'Direction':>13}{'Q10-Q90':>12}{'Forecast origin':>23}"
-    )
-    print("-" * 96)
-
+    print("\nMatured ensemble comparison")
+    print("-" * 82)
+    print(f"{'Horizon':<9}{'Predicted':>14}{'Actual':>14}{'MAE':>10}{'Bias':>10}{'Dir':>9}{'Band':>10}")
+    print("-" * 82)
     for hour in TARGET_HOURS:
-        horizon = f"{hour}h"
-        score = reliability.get(horizon)
+        key = f"{hour}h"
+        score = reliability.get(key)
         if not score:
-            print(f"+{horizon:<8}{'not enough history yet':>34}")
+            print(f"+{key:<8}{'not enough history yet':>34}")
             continue
-
-        origin = datetime.fromisoformat(score["forecast_origin_at"]).strftime("%Y-%m-%d %H:%M")
+        band = score["within_q10_q90"]
         print(
-            f"+{horizon:<8}"
+            f"+{key:<8}"
             f"${score['predicted_price_usd']:>12,.2f}"
             f"${score['actual_price_usd']:>12,.2f}"
-            f"{score['absolute_error_pct']:>10.3f}%"
-            f"{'correct' if score['direction_correct'] else 'wrong':>13}"
-            f"{'inside' if score['within_q10_q90'] else 'outside':>12}"
-            f"{origin:>23}"
+            f"{score['absolute_error_pct']:>9.3f}%"
+            f"{score['signed_error_pct']:>9.3f}%"
+            f"{'OK' if score['direction_correct'] else 'MISS':>9}"
+            f"{('in' if band else 'out') if band is not None else '--':>10}"
         )
 
 
 def main() -> None:
-    closes, close_timestamps = get_completed_hourly_candles()
-    current_price = float(closes[-1])
-    latest_close_at = datetime.fromtimestamp(close_timestamps[-1], tz=timezone.utc)
-
-    print(f"Loaded {len(closes)} completed hourly candles")
-    print(f"Latest BTC/USD close: ${current_price:,.2f} at {latest_close_at.isoformat()}")
-
-    history = load_forecast_history()
-    reliability = score_forecast_history(history, closes, close_timestamps)
-
-    model = load_model()
-    outputs = list(
-        model.predict_batch(
-            contexts=[closes],
-            horizon=FORECAST_HOURS,
-            return_quantiles=True,
-            use_symmetric_averaging=False,
-        )
+    data = fetch_kraken_hourly(512)
+    print(f"Loaded {len(data.closes)} completed hourly candles")
+    print(
+        f"Latest BTC/USD close: ${float(data.closes[-1]):,.2f} at "
+        f"{datetime.fromtimestamp(data.timestamps[-1], tz=timezone.utc).isoformat()}"
     )
 
-    result = outputs[0]
-    forecast = result.forecast
-    quantiles = result.quantiles
+    history = load_forecast_history()
+    reliability = score_forecast_history(history, data.closes, data.timestamps)
+    summary = performance_summary(history, data.closes, data.timestamps)
 
-    predictions: dict[str, dict[str, float]] = {}
-    for hour in TARGET_HOURS:
-        idx = hour - 1
-        price = float(forecast[idx])
-        q10 = float(quantiles[idx, 0])
-        q50 = float(quantiles[idx, 4])
-        q90 = float(quantiles[idx, 8])
-        change_pct = (price / current_price - 1.0) * 100.0
-
-        predictions[f"{hour}h"] = {
-            "price_usd": round(price, 2),
-            "change_pct": round(change_pct, 4),
-            "q10_usd": round(q10, 2),
-            "q50_usd": round(q50, 2),
-            "q90_usd": round(q90, 2),
-        }
-
+    model = load_timesfm()
+    engine_output = build_forecast(model, data, history)
     output: dict[str, Any] = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "pair": "BTC/USD",
         "source": "Kraken hourly OHLC",
-        "model": MODEL_ID,
-        "latest_close_at": latest_close_at.isoformat(),
-        "latest_close_usd": round(current_price, 2),
-        "predictions": predictions,
+        **engine_output,
         "forecast_reliability": reliability,
-        # Preserve the old field for consumers that still expect the +2h score.
+        "performance_summary": summary,
         "previous_forecast_reliability": reliability.get("2h"),
     }
 
     OUTPUT_PATH.write_text(json.dumps(output, indent=2) + "\n")
     save_forecast_history(history, output)
-
     tweet = build_tweet(output)
     TWEET_PATH.write_text(tweet + "\n")
 
-    print("\nBTC/USD TimesFM 3 forecast")
-    print("-" * 72)
-    print(f"{'Horizon':<9}{'Forecast':>16}{'Change':>12}{'Q10':>16}{'Q90':>16}")
-    print("-" * 72)
-
-    for horizon, prediction in predictions.items():
+    print(f"\nRegime: {output['regime']}")
+    print(f"Model weights: {output['model_weights']}")
+    print("\nBTC/USD ensemble forecast")
+    print("-" * 78)
+    print(f"{'Horizon':<9}{'Forecast':>16}{'Change':>12}{'Q10':>16}{'Q90':>16}{'Agree':>9}")
+    print("-" * 78)
+    for horizon, prediction in output["predictions"].items():
         print(
             f"+{horizon:<8}"
             f"${prediction['price_usd']:>14,.2f}"
             f"{prediction['change_pct']:>11.3f}%"
             f"${prediction['q10_usd']:>14,.2f}"
             f"${prediction['q90_usd']:>14,.2f}"
+            f"{prediction['model_agreement'] * 100:>8.0f}%"
         )
-
     print_reliability(reliability)
-
     print(f"\nSaved forecast to {OUTPUT_PATH}")
-    print(f"Saved forecast history to {STATE_PATH} ({min(len(history) + 1, HISTORY_LIMIT)} snapshots max)")
     print(f"Saved X post to {TWEET_PATH}:\n\n{tweet}")
 
 

--- a/forecast_engine.py
+++ b/forecast_engine.py
@@ -1,0 +1,409 @@
+"""Forecasting engine for BTC/USD.
+
+TimesFM predicts log returns across several context windows. The engine combines
+those forecasts with simple baselines, market/regime features, model agreement,
+and empirical interval calibration from recent forecast history.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import numpy as np
+import requests
+from timesfm3 import ModelConfig, TimesFM3Evaluator
+
+
+KRAKEN_OHLC_URL = "https://api.kraken.com/0/public/OHLC"
+PAIR = "XBTUSD"
+INTERVAL_MINUTES = 60
+MODEL_ID = "google/timesfm-3.0-pytorch"
+TARGET_HOURS = (2, 4, 8, 16)
+FORECAST_HOURS = max(TARGET_HOURS)
+CONTEXT_WINDOWS = (168, 336, 512)
+
+
+@dataclass
+class MarketData:
+    timestamps: list[int]
+    opens: np.ndarray
+    highs: np.ndarray
+    lows: np.ndarray
+    closes: np.ndarray
+    volumes: np.ndarray
+
+    @property
+    def returns(self) -> np.ndarray:
+        return np.diff(np.log(self.closes.astype(np.float64))).astype(np.float32)
+
+
+def fetch_kraken_hourly(limit: int = 512) -> MarketData:
+    response = requests.get(
+        KRAKEN_OHLC_URL,
+        params={"pair": PAIR, "interval": INTERVAL_MINUTES},
+        timeout=30,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if payload.get("error"):
+        raise RuntimeError(f"Kraken API error: {payload['error']}")
+
+    result = payload["result"]
+    pair_key = next(key for key in result if key != "last")
+    now = time.time()
+    completed = [
+        candle
+        for candle in result[pair_key]
+        if float(candle[0]) + INTERVAL_MINUTES * 60 <= now
+    ]
+    if len(completed) < 64:
+        raise RuntimeError(f"Not enough completed candles: {len(completed)}")
+    completed = completed[-limit:]
+
+    def arr(index: int) -> np.ndarray:
+        return np.asarray([float(c[index]) for c in completed], dtype=np.float32)
+
+    return MarketData(
+        timestamps=[int(float(c[0])) + INTERVAL_MINUTES * 60 for c in completed],
+        opens=arr(1),
+        highs=arr(2),
+        lows=arr(3),
+        closes=arr(4),
+        volumes=arr(6),
+    )
+
+
+def load_timesfm() -> TimesFM3Evaluator:
+    print(f"Loading {MODEL_ID} on CPU...")
+    return TimesFM3Evaluator(
+        ModelConfig(
+            checkpoint_path=MODEL_ID,
+            per_core_batch_size=1,
+            device="cpu",
+        )
+    )
+
+
+def _safe_std(values: np.ndarray) -> float:
+    return float(np.std(values, ddof=1)) if len(values) > 1 else 0.0
+
+
+def _rsi(closes: np.ndarray, period: int = 14) -> float:
+    if len(closes) <= period:
+        return 50.0
+    delta = np.diff(closes.astype(np.float64))[-period:]
+    gains = np.clip(delta, 0, None)
+    losses = -np.clip(delta, None, 0)
+    avg_gain = float(np.mean(gains))
+    avg_loss = float(np.mean(losses))
+    if avg_loss == 0:
+        return 100.0 if avg_gain > 0 else 50.0
+    rs = avg_gain / avg_loss
+    return 100.0 - 100.0 / (1.0 + rs)
+
+
+def _pct_change(closes: np.ndarray, hours: int) -> float:
+    if len(closes) <= hours:
+        return 0.0
+    return (float(closes[-1]) / float(closes[-1 - hours]) - 1.0) * 100.0
+
+
+def market_features(data: MarketData) -> dict[str, Any]:
+    returns = data.returns.astype(np.float64)
+    ranges = (data.highs.astype(np.float64) - data.lows) / data.closes * 100.0
+    log_volume = np.log1p(data.volumes.astype(np.float64))
+
+    def vol(hours: int) -> float:
+        return _safe_std(returns[-hours:]) * 100.0
+
+    volume_window = log_volume[-168:]
+    volume_std = _safe_std(volume_window)
+    volume_z = (
+        (float(log_volume[-1]) - float(np.mean(volume_window))) / volume_std
+        if volume_std > 1e-12
+        else 0.0
+    )
+
+    latest_dt = datetime.fromtimestamp(data.timestamps[-1], tz=timezone.utc)
+    return {
+        "close_usd": round(float(data.closes[-1]), 2),
+        "volatility_6h_pct": round(vol(6), 4),
+        "volatility_24h_pct": round(vol(24), 4),
+        "volatility_7d_pct": round(vol(168), 4),
+        "range_24h_avg_pct": round(float(np.mean(ranges[-24:])), 4),
+        "volume_zscore_7d": round(volume_z, 4),
+        "rsi_14": round(_rsi(data.closes), 2),
+        "momentum_6h_pct": round(_pct_change(data.closes, 6), 4),
+        "momentum_24h_pct": round(_pct_change(data.closes, 24), 4),
+        "momentum_7d_pct": round(_pct_change(data.closes, 168), 4),
+        "hour_utc": latest_dt.hour,
+        "weekday_utc": latest_dt.weekday(),
+        "hour_sin": round(math.sin(2 * math.pi * latest_dt.hour / 24), 4),
+        "hour_cos": round(math.cos(2 * math.pi * latest_dt.hour / 24), 4),
+        "weekday_sin": round(math.sin(2 * math.pi * latest_dt.weekday() / 7), 4),
+        "weekday_cos": round(math.cos(2 * math.pi * latest_dt.weekday() / 7), 4),
+    }
+
+
+def detect_regime(features: dict[str, Any]) -> str:
+    vol24 = float(features["volatility_24h_pct"])
+    vol7d = max(float(features["volatility_7d_pct"]), 1e-6)
+    mom24 = abs(float(features["momentum_24h_pct"]))
+    rsi = float(features["rsi_14"])
+    if vol24 > vol7d * 1.35:
+        return "high_volatility"
+    if mom24 > max(1.0, vol24 * math.sqrt(24) * 1.2) or rsi >= 70 or rsi <= 30:
+        return "trending"
+    return "range"
+
+
+def _forecast_prices_from_return_path(
+    current_price: float,
+    return_path: np.ndarray,
+) -> dict[str, float]:
+    cumulative = np.cumsum(return_path.astype(np.float64))
+    return {
+        f"{hour}h": float(current_price * math.exp(float(cumulative[hour - 1])))
+        for hour in TARGET_HOURS
+    }
+
+
+def timesfm_multi_context(
+    model: TimesFM3Evaluator,
+    data: MarketData,
+) -> dict[str, dict[str, dict[str, float]]]:
+    """Forecast log returns using several context windows."""
+    returns = data.returns
+    available = [window for window in CONTEXT_WINDOWS if len(returns) >= window]
+    if not available:
+        available = [len(returns)]
+
+    outputs = list(
+        model.predict_batch(
+            contexts=[returns[-window:] for window in available],
+            horizon=FORECAST_HOURS,
+            return_quantiles=True,
+            use_symmetric_averaging=False,
+        )
+    )
+    current_price = float(data.closes[-1])
+    forecasts: dict[str, dict[str, dict[str, float]]] = {}
+
+    for window, result in zip(available, outputs, strict=True):
+        point = np.asarray(result.forecast, dtype=np.float64)
+        quantiles = np.asarray(result.quantiles, dtype=np.float64)
+        point_prices = _forecast_prices_from_return_path(current_price, point)
+        q10_prices = _forecast_prices_from_return_path(current_price, quantiles[:, 0])
+        q50_prices = _forecast_prices_from_return_path(current_price, quantiles[:, 4])
+        q90_prices = _forecast_prices_from_return_path(current_price, quantiles[:, 8])
+
+        name = f"timesfm_{window}h"
+        forecasts[name] = {}
+        for hour in TARGET_HOURS:
+            key = f"{hour}h"
+            forecasts[name][key] = {
+                "price_usd": point_prices[key],
+                "q10_usd": q10_prices[key],
+                "q50_usd": q50_prices[key],
+                "q90_usd": q90_prices[key],
+            }
+    return forecasts
+
+
+def baseline_forecasts(data: MarketData) -> dict[str, dict[str, dict[str, float]]]:
+    returns = data.returns.astype(np.float64)
+    current_price = float(data.closes[-1])
+    recent_sigma = max(_safe_std(returns[-168:]), 1e-6)
+
+    persistence_path = np.zeros(FORECAST_HOURS, dtype=np.float64)
+
+    drift = float(np.mean(returns[-168:]))
+    drift = float(np.clip(drift, -2.0 * recent_sigma, 2.0 * recent_sigma))
+    drift_path = np.full(FORECAST_HOURS, drift, dtype=np.float64)
+
+    x = returns[-169:-1] if len(returns) >= 170 else returns[:-1]
+    y = returns[-168:] if len(returns) >= 170 else returns[1:]
+    if len(x) >= 10 and float(np.var(x)) > 1e-12:
+        phi = float(np.cov(x, y, ddof=0)[0, 1] / np.var(x))
+        phi = float(np.clip(phi, -0.95, 0.95))
+        intercept = float(np.mean(y) - phi * np.mean(x))
+    else:
+        phi, intercept = 0.0, drift
+
+    ar_path = np.empty(FORECAST_HOURS, dtype=np.float64)
+    last = float(returns[-1])
+    for i in range(FORECAST_HOURS):
+        last = intercept + phi * last
+        last = float(np.clip(last, -4.0 * recent_sigma, 4.0 * recent_sigma))
+        ar_path[i] = last
+
+    models = {
+        "persistence": persistence_path,
+        "drift_7d": drift_path,
+        "ar1": ar_path,
+    }
+    result: dict[str, dict[str, dict[str, float]]] = {}
+    for name, path in models.items():
+        prices = _forecast_prices_from_return_path(current_price, path)
+        result[name] = {key: {"price_usd": price} for key, price in prices.items()}
+    return result
+
+
+def model_weights(model_names: list[str], regime: str) -> dict[str, float]:
+    timesfm_names = [name for name in model_names if name.startswith("timesfm_")]
+    if regime == "high_volatility":
+        family = {"timesfm": 0.72, "persistence": 0.14, "drift_7d": 0.04, "ar1": 0.10}
+    elif regime == "trending":
+        family = {"timesfm": 0.65, "persistence": 0.08, "drift_7d": 0.17, "ar1": 0.10}
+    else:
+        family = {"timesfm": 0.57, "persistence": 0.24, "drift_7d": 0.06, "ar1": 0.13}
+
+    context_rank = {"timesfm_168h": 0.25, "timesfm_336h": 0.35, "timesfm_512h": 0.40}
+    raw_context = np.asarray([context_rank.get(name, 1.0) for name in timesfm_names], dtype=float)
+    if len(raw_context):
+        raw_context /= raw_context.sum()
+
+    weights = {
+        name: family["timesfm"] * float(weight)
+        for name, weight in zip(timesfm_names, raw_context, strict=True)
+    }
+    for name in ("persistence", "drift_7d", "ar1"):
+        if name in model_names:
+            weights[name] = family[name]
+    total = sum(weights.values())
+    return {name: weight / total for name, weight in weights.items()}
+
+
+def empirical_calibration_multiplier(
+    history: list[dict[str, Any]],
+    actual_by_timestamp: dict[int, float],
+    hour: int,
+    target_coverage: float = 0.80,
+) -> tuple[float, int, float | None]:
+    observations: list[bool] = []
+    for snapshot in history[-48:]:
+        try:
+            origin = datetime.fromisoformat(snapshot["latest_close_at"])
+            if origin.tzinfo is None:
+                origin = origin.replace(tzinfo=timezone.utc)
+            target = int(origin.astimezone(timezone.utc).timestamp()) + hour * 3600
+            actual = actual_by_timestamp.get(target)
+            pred = snapshot["predictions"][f"{hour}h"]
+            if actual is None:
+                continue
+            observations.append(float(pred["q10_usd"]) <= actual <= float(pred["q90_usd"]))
+        except (KeyError, TypeError, ValueError):
+            continue
+
+    if len(observations) < 10:
+        return 1.0, len(observations), None
+    coverage = sum(observations) / len(observations)
+    multiplier = math.sqrt(target_coverage / max(coverage, 0.10))
+    return float(np.clip(multiplier, 0.75, 1.75)), len(observations), coverage
+
+
+def ensemble_forecast(
+    data: MarketData,
+    model_predictions: dict[str, dict[str, dict[str, float]]],
+    regime: str,
+    calibration: dict[str, tuple[float, int, float | None]],
+) -> tuple[dict[str, dict[str, float]], dict[str, float]]:
+    names = list(model_predictions)
+    weights = model_weights(names, regime)
+    current_price = float(data.closes[-1])
+    predictions: dict[str, dict[str, float]] = {}
+
+    for hour in TARGET_HOURS:
+        key = f"{hour}h"
+        log_changes: list[float] = []
+        model_prices: list[float] = []
+        model_ws: list[float] = []
+        timesfm_half_widths: list[float] = []
+
+        for name in names:
+            item = model_predictions[name][key]
+            price = float(item["price_usd"])
+            weight = weights.get(name, 0.0)
+            if weight <= 0:
+                continue
+            log_changes.append(math.log(price / current_price))
+            model_prices.append(price)
+            model_ws.append(weight)
+            if "q10_usd" in item and "q90_usd" in item:
+                timesfm_half_widths.append(
+                    max(0.0, (float(item["q90_usd"]) - float(item["q10_usd"])) / 2.0)
+                )
+
+        normalized = np.asarray(model_ws, dtype=float)
+        normalized /= normalized.sum()
+        ensemble_log_change = float(np.dot(normalized, np.asarray(log_changes)))
+        price = current_price * math.exp(ensemble_log_change)
+        dispersion = float(math.sqrt(np.dot(normalized, (np.asarray(model_prices) - price) ** 2)))
+        tf_width = float(np.mean(timesfm_half_widths)) if timesfm_half_widths else 0.0
+        base_half_width = max(tf_width, dispersion * 1.5, current_price * 0.0005)
+
+        multiplier, sample_count, empirical_coverage = calibration[key]
+        half_width = base_half_width * multiplier
+        q10 = max(0.01, price - half_width)
+        q90 = price + half_width
+
+        moves = [1 if p > current_price else -1 if p < current_price else 0 for p in model_prices]
+        agreement = max(moves.count(1), moves.count(-1), moves.count(0)) / len(moves)
+        predictions[key] = {
+            "price_usd": round(price, 2),
+            "change_pct": round((price / current_price - 1.0) * 100.0, 4),
+            "q10_usd": round(q10, 2),
+            "q50_usd": round(price, 2),
+            "q90_usd": round(q90, 2),
+            "model_agreement": round(agreement, 4),
+            "interval_calibration_multiplier": round(multiplier, 4),
+            "calibration_samples": sample_count,
+            "empirical_q10_q90_coverage": (
+                round(empirical_coverage, 4) if empirical_coverage is not None else None
+            ),
+        }
+
+    return predictions, weights
+
+
+def build_forecast(
+    model: TimesFM3Evaluator,
+    data: MarketData,
+    history: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    history = history or []
+    features = market_features(data)
+    regime = detect_regime(features)
+    models = {**timesfm_multi_context(model, data), **baseline_forecasts(data)}
+
+    actuals = dict(zip(data.timestamps, map(float, data.closes), strict=True))
+    calibration = {
+        f"{hour}h": empirical_calibration_multiplier(history, actuals, hour)
+        for hour in TARGET_HOURS
+    }
+    predictions, weights = ensemble_forecast(data, models, regime, calibration)
+
+    return {
+        "model": MODEL_ID,
+        "forecast_method": "log-return multi-context ensemble",
+        "latest_close_at": datetime.fromtimestamp(data.timestamps[-1], tz=timezone.utc).isoformat(),
+        "latest_close_usd": round(float(data.closes[-1]), 2),
+        "market_features": features,
+        "regime": regime,
+        "model_weights": {k: round(v, 4) for k, v in weights.items()},
+        "model_predictions": {
+            model_name: {
+                horizon: {
+                    key: round(value, 4) if isinstance(value, float) else value
+                    for key, value in values.items()
+                }
+                for horizon, values in horizons.items()
+            }
+            for model_name, horizons in models.items()
+        },
+        "predictions": predictions,
+    }


### PR DESCRIPTION
## Summary
- forecast BTC log returns instead of only raw price levels
- run TimesFM across multiple context windows (168h, 336h, 512h)
- ensemble TimesFM with persistence, 7-day drift, and AR(1) baselines
- detect range, trending, and high-volatility regimes and adjust ensemble weights
- add volatility, range, volume, RSI, momentum, and time-of-week features
- report model agreement and calibrate forecast intervals from recent empirical coverage
- keep multi-horizon reliability metrics for 2h, 4h, 8h, and 16h forecasts
- add a walk-forward backtesting CLI and manual GitHub Actions backtest workflow
- document the new forecasting and validation approach

## Files
- `forecast_engine.py`
- `btc_forecast.py`
- `backtest.py`
- `.github/workflows/backtest.yml`
- `README.md`

## Notes
The scheduled production workflow remains on the existing hourly wake-up / 2-hour forecast guard. The added backtest workflow is manual so it does not consume Actions minutes continuously.