### PR TITLE
Add adaptive performance-based ensemble weighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BTC Forecast Ensemble
 
-A BTC/USD forecasting experiment built around **TimesFM 3**, Kraken hourly candles, multiple baselines, regime detection, calibrated uncertainty and walk-forward backtesting.
+A BTC/USD forecasting experiment built around **TimesFM 3**, Kraken hourly candles, multiple baselines, regime detection, adaptive ensemble weighting, calibrated uncertainty and walk-forward backtesting.
 
 ## What changed
 
@@ -9,7 +9,8 @@ The production forecast no longer feeds raw BTC prices into one TimesFM context.
 - forecasts **hourly log returns** and reconstructs future prices
 - runs TimesFM with **168h, 336h and 512h** context windows
 - compares/ensembles TimesFM with **persistence, 7-day drift and AR(1)** baselines
-- changes ensemble weights for **range, trending and high-volatility** regimes
+- starts from regime-specific priors for **range, trending and high-volatility** markets
+- adapts model weights separately for **2h, 4h, 8h and 16h** from matured out-of-sample performance
 - derives market context from volatility, volume, high-low range, RSI, momentum and time-of-day/day-of-week
 - reports **model agreement** as an additional confidence signal
 - calibrates the Q10-Q90 interval from recent empirical coverage once enough samples exist
@@ -36,7 +37,7 @@ The predicted return path is accumulated and converted back into a BTC price. Re
 
 ## Multi-context TimesFM
 
-Each forecast uses three views of the market:
+Each forecast uses three views of the market when enough completed candles are available:
 
 ```text
 168 hours   = 7 days
@@ -60,11 +61,44 @@ These are deliberately simple. If TimesFM cannot consistently beat persistence i
 
 Each run records 6h/24h/7d realized volatility, average high-low range, volume z-score, RSI(14), 6h/24h/7d momentum and cyclic hour/day features.
 
-Those features classify the market as `range`, `trending` or `high_volatility`. The regime changes the relative weights of TimesFM, persistence, drift and AR(1), and the features are saved for later analysis.
+Those features classify the market as `range`, `trending` or `high_volatility`. The regime defines the initial prior weights and is also used to select comparable historical forecasts for adaptive weighting.
+
+## Adaptive ensemble weighting
+
+The ensemble no longer relies only on fixed hand-tuned weights. For each horizon independently, it scores matured historical predictions from every underlying model and adjusts the weights from measured out-of-sample performance.
+
+The adaptive score uses:
+
+- recent MAE % as the main signal
+- direction accuracy as a smaller reward
+- signed bias as a penalty
+- performance relative to the persistence baseline
+
+The current market regime is preferred when there are enough matching samples. If regime-specific history is sparse, the system can use all recent regimes. With fewer than 6 matured samples per current model it falls back to the original static regime prior.
+
+Adaptation is deliberately gradual. The learned distribution is blended with the static prior and reaches at most 80% of the final decision after enough observations. Every active model is constrained to a 3% minimum and 55% maximum weight, preventing one short lucky streak from taking over the ensemble.
+
+If the non-persistence models are collectively failing to beat persistence, the weighting logic explicitly boosts the persistence baseline before the final bounded normalization.
+
+Only target prices already present in completed historical candles are used when computing weights. Future outcomes are never consulted, avoiding look-ahead leakage in production and walk-forward tests.
+
+`forecast.json` exposes the result per horizon:
+
+```text
+model_weights.2h
+model_weights.4h
+model_weights.8h
+model_weights.16h
+weighting_diagnostics.<horizon>
+```
+
+The diagnostics include static prior weight, recent sample count, MAE, direction accuracy, signed bias, raw adaptive score, learned weight, final weight, persistence edge, blend factor and whether the persistence fallback was activated.
+
+The current implementation learns from the rolling Actions forecast history. GitHub issue #5 tracks moving that learning history to a durable long-term dataset so adaptive weighting can eventually use substantially more observations.
 
 ## Confidence and uncertainty
 
-For each horizon the output includes the ensemble price, change from current price, Q10/Q50/Q90 interval, model agreement, interval calibration multiplier and empirical Q10-Q90 coverage once enough history exists.
+For each horizon the output includes the ensemble price, change from current price, Q10/Q50/Q90 interval, model agreement, weighting mode/sample count, interval calibration multiplier and empirical Q10-Q90 coverage once enough history exists.
 
 The TimesFM quantile paths provide the starting uncertainty band. The band is widened when the models disagree and, after at least 10 matured samples, adjusted toward approximately 80% empirical Q10-Q90 coverage.
 
@@ -89,22 +123,13 @@ Scheduled forecasts post to X automatically. Manual runs only post when `post_to
 
 ## X posting
 
-Posting uses Twikit with the `X_COOKIES_JSON` repository secret. Example:
-
-```text
-BTC/USD ensemble forecast
-Now $100,000 | trending
-2h $100,200 (+0.20%) | 4h $100,450 (+0.45%)
-8h $100,800 (+0.80%) | 16h $101,100 (+1.10%)
-Prev err: 2h 0.31% | 4h 0.42% | 8h 0.75% | 16h 1.10%
-Experimental - not financial advice.
-```
+Posting uses Twikit with the `X_COOKIES_JSON` repository secret. The generated post is reformatted by `format_tweet.py` into the compact emoji-rich X layout before posting.
 
 Twikit is an unofficial X client and can break when X changes its internal frontend/API behavior.
 
 ## Backtesting
 
-`backtest.py` performs walk-forward historical forecasts and compares the ensemble against every underlying model.
+`backtest.py` performs walk-forward historical forecasts and now compares the **adaptive ensemble**, the equivalent **static-prior ensemble**, persistence, each TimesFM context and the other simple baselines.
 
 The manual **BTC Forecast Backtest** GitHub workflow defaults to 90 days of history and 60 walk-forward samples.
 
@@ -116,13 +141,23 @@ Run locally:
 python backtest.py --days 90 --samples 60
 ```
 
-The result is written to `backtest_report.json` with MAE %, mean signed error, direction accuracy, ensemble interval coverage and ensemble performance by regime.
+The backtest feeds only prior forecast snapshots into each new forecast, so adaptive weights can learn during the walk-forward run without seeing future targets.
 
-The most important comparison is whether the ensemble and the individual TimesFM contexts beat `persistence` consistently.
+The result is written to `backtest_report.json` with MAE %, mean signed error, direction accuracy, ensemble interval coverage and adaptive ensemble performance by regime.
+
+The most important comparisons are whether the adaptive ensemble beats the static ensemble and whether either consistently beats `persistence`.
+
+## Tests
+
+Adaptive-weight safeguards have unit coverage for sparse-history fallback, favoring empirically better models, normalization and per-model weight floors/caps:
+
+```bash
+python -m unittest test_adaptive_weights.py
+```
 
 ## Production output
 
-`forecast.json` contains the latest BTC/USD close, market features, regime, model weights, per-model forecasts, ensemble 2h/4h/8h/16h forecasts, model agreement, calibrated uncertainty, latest matured reliability and rolling performance summary.
+`forecast.json` contains the latest BTC/USD close, market features, regime, per-horizon adaptive model weights, weighting diagnostics, per-model forecasts, ensemble 2h/4h/8h/16h forecasts, model agreement, calibrated uncertainty, latest matured reliability and rolling performance summary.
 
 Forecast history lives in `.state/previous_forecast.json` and is persisted with the GitHub Actions cache rather than committed to the repository.
 
@@ -134,6 +169,7 @@ Python 3.11:
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
+python -m unittest test_adaptive_weights.py
 python btc_forecast.py
 ```
 

--- a/backtest.py
+++ b/backtest.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -18,7 +19,13 @@ from typing import Any
 import numpy as np
 import requests
 
-from forecast_engine import MarketData, TARGET_HOURS, build_forecast, load_timesfm
+from forecast_engine import (
+    MarketData,
+    TARGET_HOURS,
+    build_forecast,
+    load_timesfm,
+    static_model_weights,
+)
 
 
 BINANCE_KLINES = "https://api.binance.com/api/v3/klines"
@@ -57,7 +64,6 @@ def fetch_binance_history(days: int) -> MarketData:
     if len(rows) < 550:
         raise RuntimeError(f"Not enough historical candles: {len(rows)}")
 
-    # Binance timestamps are candle open times; convert to completed-candle time.
     timestamps = [int(row[0] / 1000) + 3600 for row in rows]
     return MarketData(
         timestamps=timestamps,
@@ -95,6 +101,17 @@ def score_one(current: float, predicted: float, actual: float) -> dict[str, Any]
     }
 
 
+def static_ensemble_price(forecast: dict[str, Any], horizon: str) -> float:
+    current = float(forecast["latest_close_usd"])
+    model_predictions = forecast["model_predictions"]
+    weights = static_model_weights(list(model_predictions), forecast["regime"])
+    log_change = 0.0
+    for name, weight in weights.items():
+        price = float(model_predictions[name][horizon]["price_usd"])
+        log_change += weight * math.log(price / current)
+    return current * math.exp(log_change)
+
+
 def summarize(samples: list[dict[str, Any]]) -> dict[str, Any]:
     result: dict[str, Any] = {}
     for horizon in ("2h", "4h", "8h", "16h"):
@@ -107,9 +124,14 @@ def summarize(samples: list[dict[str, Any]]) -> dict[str, Any]:
             current = sample["current_price"]
             ensemble = sample["forecast"]["predictions"][horizon]
             score = score_one(current, ensemble["price_usd"], actual)
-            per_model.setdefault("ensemble", []).append(score)
+            per_model.setdefault("adaptive_ensemble", []).append(score)
             ensemble_coverage.append(ensemble["q10_usd"] <= actual <= ensemble["q90_usd"])
             regime_scores.setdefault(sample["forecast"]["regime"], []).append(score)
+
+            static_price = static_ensemble_price(sample["forecast"], horizon)
+            per_model.setdefault("static_ensemble", []).append(
+                score_one(current, static_price, actual)
+            )
 
             for name, horizons in sample["forecast"]["model_predictions"].items():
                 per_model.setdefault(name, []).append(
@@ -124,7 +146,7 @@ def summarize(samples: list[dict[str, Any]]) -> dict[str, Any]:
                 "mean_signed_error_pct": round(float(np.mean([s["signed_error_pct"] for s in scores])), 4),
                 "direction_accuracy": round(float(np.mean([s["direction_correct"] for s in scores])), 4),
             }
-            if name == "ensemble":
+            if name == "adaptive_ensemble":
                 models[name]["q10_q90_coverage"] = round(float(np.mean(ensemble_coverage)), 4)
 
         by_regime = {
@@ -135,8 +157,19 @@ def summarize(samples: list[dict[str, Any]]) -> dict[str, Any]:
             }
             for regime, scores in sorted(regime_scores.items())
         }
-        result[horizon] = {"models": models, "ensemble_by_regime": by_regime}
+        result[horizon] = {"models": models, "adaptive_ensemble_by_regime": by_regime}
     return result
+
+
+def history_snapshot(forecast: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "latest_close_at": forecast["latest_close_at"],
+        "latest_close_usd": forecast["latest_close_usd"],
+        "regime": forecast["regime"],
+        "model_predictions": forecast["model_predictions"],
+        "predictions": forecast["predictions"],
+        "model_weights": forecast["model_weights"],
+    }
 
 
 def main() -> None:
@@ -155,10 +188,11 @@ def main() -> None:
     indices = sorted(set(map(int, candidate_indices)))
     model = load_timesfm()
     samples: list[dict[str, Any]] = []
+    history: list[dict[str, Any]] = []
 
     for number, index in enumerate(indices, start=1):
         context = slice_market(data, index)
-        forecast = build_forecast(model, context, history=[])
+        forecast = build_forecast(model, context, history=history)
         actuals = {
             f"{hour}h": float(data.closes[index + hour])
             for hour in TARGET_HOURS
@@ -171,7 +205,13 @@ def main() -> None:
                 "forecast": forecast,
             }
         )
-        print(f"Backtest {number}/{len(indices)}: {samples[-1]['origin_at']} ({forecast['regime']})")
+        history.append(history_snapshot(forecast))
+        history = history[-72:]
+        modes = sorted({str(p["weighting_mode"]) for p in forecast["predictions"].values()})
+        print(
+            f"Backtest {number}/{len(indices)}: {samples[-1]['origin_at']} "
+            f"({forecast['regime']}; {','.join(modes)})"
+        )
 
     report = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -184,11 +224,12 @@ def main() -> None:
 
     print("\nBacktest summary")
     for horizon, info in report["summary"].items():
-        ensemble = info["models"]["ensemble"]
+        adaptive = info["models"]["adaptive_ensemble"]
+        static = info["models"]["static_ensemble"]
         persistence = info["models"].get("persistence", {})
         print(
-            f"{horizon}: ensemble MAE {ensemble['mae_pct']:.3f}% / dir "
-            f"{ensemble['direction_accuracy']:.1%}; persistence MAE "
+            f"{horizon}: adaptive MAE {adaptive['mae_pct']:.3f}% / "
+            f"static {static['mae_pct']:.3f}% / persistence "
             f"{persistence.get('mae_pct', float('nan')):.3f}%"
         )
     print(f"\nSaved {REPORT_PATH}")

--- a/forecast_engine.py
+++ b/forecast_engine.py
@@ -1,8 +1,9 @@
 """Forecasting engine for BTC/USD.
 
 TimesFM predicts log returns across several context windows. The engine combines
-those forecasts with simple baselines, market/regime features, model agreement,
-and empirical interval calibration from recent forecast history.
+those forecasts with simple baselines, market/regime features, adaptive
+performance-based weighting, model agreement, and empirical interval calibration
+from recent forecast history.
 """
 
 from __future__ import annotations
@@ -25,6 +26,16 @@ MODEL_ID = "google/timesfm-3.0-pytorch"
 TARGET_HOURS = (2, 4, 8, 16)
 FORECAST_HOURS = max(TARGET_HOURS)
 CONTEXT_WINDOWS = (168, 336, 512)
+
+ADAPTIVE_HISTORY_LIMIT = 72
+ADAPTIVE_MIN_SAMPLES = 6
+ADAPTIVE_FULL_SAMPLES = 24
+ADAPTIVE_MAX_BLEND = 0.80
+ADAPTIVE_MIN_WEIGHT = 0.03
+ADAPTIVE_MAX_WEIGHT = 0.55
+ADAPTIVE_MAE_LAMBDA = 2.5
+ADAPTIVE_DIRECTION_REWARD = 0.25
+PERSISTENCE_FALLBACK_BOOST = 0.12
 
 
 @dataclass
@@ -253,7 +264,8 @@ def baseline_forecasts(data: MarketData) -> dict[str, dict[str, dict[str, float]
     return result
 
 
-def model_weights(model_names: list[str], regime: str) -> dict[str, float]:
+def static_model_weights(model_names: list[str], regime: str) -> dict[str, float]:
+    """Return the existing hand-tuned regime prior."""
     timesfm_names = [name for name in model_names if name.startswith("timesfm_")]
     if regime == "high_volatility":
         family = {"timesfm": 0.72, "persistence": 0.14, "drift_7d": 0.04, "ar1": 0.10}
@@ -276,6 +288,278 @@ def model_weights(model_names: list[str], regime: str) -> dict[str, float]:
             weights[name] = family[name]
     total = sum(weights.values())
     return {name: weight / total for name, weight in weights.items()}
+
+
+model_weights = static_model_weights
+
+
+def _direction(value: float, epsilon: float = 1e-12) -> int:
+    return 1 if value > epsilon else -1 if value < -epsilon else 0
+
+
+def _bounded_normalize(
+    weights: dict[str, float],
+    floor: float = ADAPTIVE_MIN_WEIGHT,
+    cap: float = ADAPTIVE_MAX_WEIGHT,
+) -> dict[str, float]:
+    """Normalize weights while respecting per-model floors and caps."""
+    names = list(weights)
+    if not names:
+        return {}
+    if floor * len(names) > 1.0 or cap * len(names) < 1.0:
+        raise ValueError("Weight floor/cap cannot produce a normalized distribution")
+
+    raw = {name: max(float(weights[name]), 1e-12) for name in names}
+    result: dict[str, float] = {}
+    remaining = set(names)
+    remaining_mass = 1.0
+
+    while remaining:
+        raw_total = sum(raw[name] for name in remaining)
+        proposed = {
+            name: remaining_mass * raw[name] / raw_total
+            for name in remaining
+        }
+        low = [name for name, value in proposed.items() if value < floor - 1e-12]
+        high = [name for name, value in proposed.items() if value > cap + 1e-12]
+
+        if not low and not high:
+            result.update(proposed)
+            break
+
+        fixed = False
+        for name in low:
+            result[name] = floor
+            remaining.remove(name)
+            remaining_mass -= floor
+            fixed = True
+        for name in high:
+            if name not in remaining:
+                continue
+            result[name] = cap
+            remaining.remove(name)
+            remaining_mass -= cap
+            fixed = True
+        if not fixed:
+            result.update(proposed)
+            break
+
+    total = sum(result.values())
+    return {name: value / total for name, value in result.items()}
+
+
+def _score_history_for_model(
+    history: list[dict[str, Any]],
+    actual_by_timestamp: dict[int, float],
+    model_name: str,
+    hour: int,
+    regime: str | None,
+) -> list[dict[str, float | bool]]:
+    key = f"{hour}h"
+    scores: list[dict[str, float | bool]] = []
+
+    for snapshot in history[-ADAPTIVE_HISTORY_LIMIT:]:
+        if regime is not None and snapshot.get("regime") != regime:
+            continue
+        try:
+            origin = datetime.fromisoformat(str(snapshot["latest_close_at"]))
+            if origin.tzinfo is None:
+                origin = origin.replace(tzinfo=timezone.utc)
+            origin = origin.astimezone(timezone.utc)
+            previous_close = float(snapshot["latest_close_usd"])
+            predicted = float(snapshot["model_predictions"][model_name][key]["price_usd"])
+        except (KeyError, TypeError, ValueError):
+            continue
+
+        target = int(origin.timestamp()) + hour * 3600
+        actual = actual_by_timestamp.get(target)
+        if actual is None or actual <= 0:
+            continue
+
+        error = predicted - actual
+        scores.append(
+            {
+                "absolute_error_pct": abs(error) / actual * 100.0,
+                "signed_error_pct": error / actual * 100.0,
+                "direction_correct": _direction(predicted - previous_close)
+                == _direction(actual - previous_close),
+            }
+        )
+
+    return scores
+
+
+def _performance_metrics(scores: list[dict[str, float | bool]]) -> dict[str, float | int]:
+    return {
+        "samples": len(scores),
+        "mae_pct": float(np.mean([float(s["absolute_error_pct"]) for s in scores])),
+        "mean_signed_error_pct": float(
+            np.mean([float(s["signed_error_pct"]) for s in scores])
+        ),
+        "direction_accuracy": float(
+            np.mean([bool(s["direction_correct"]) for s in scores])
+        ),
+    }
+
+
+def adaptive_model_weights(
+    model_names: list[str],
+    regime: str,
+    hour: int,
+    history: list[dict[str, Any]],
+    actual_by_timestamp: dict[int, float],
+    enabled: bool = True,
+) -> tuple[dict[str, float], dict[str, Any]]:
+    """Blend static priors with recent out-of-sample model performance."""
+    prior = static_model_weights(model_names, regime)
+
+    regime_scores = {
+        name: _score_history_for_model(history, actual_by_timestamp, name, hour, regime)
+        for name in model_names
+    }
+    all_scores = {
+        name: _score_history_for_model(history, actual_by_timestamp, name, hour, None)
+        for name in model_names
+    }
+
+    min_regime_samples = min((len(scores) for scores in regime_scores.values()), default=0)
+    min_all_samples = min((len(scores) for scores in all_scores.values()), default=0)
+
+    if not enabled:
+        source = "disabled"
+        selected = all_scores
+    elif min_regime_samples >= ADAPTIVE_MIN_SAMPLES:
+        source = "regime"
+        selected = regime_scores
+    elif min_all_samples >= ADAPTIVE_MIN_SAMPLES:
+        source = "all_regimes"
+        selected = all_scores
+    else:
+        source = "insufficient_history"
+        selected = all_scores
+
+    metrics = {
+        name: _performance_metrics(scores) if scores else {
+            "samples": 0,
+            "mae_pct": None,
+            "mean_signed_error_pct": None,
+            "direction_accuracy": None,
+        }
+        for name, scores in selected.items()
+    }
+
+    if not enabled or source == "insufficient_history":
+        diagnostics = {
+            "mode": "static_prior",
+            "source": source,
+            "horizon": f"{hour}h",
+            "regime": regime,
+            "blend_factor": 0.0,
+            "sample_count": min_all_samples if source != "regime" else min_regime_samples,
+            "persistence_mae_pct": (
+                metrics.get("persistence", {}).get("mae_pct")
+                if "persistence" in metrics
+                else None
+            ),
+            "models": {
+                name: {
+                    **metric,
+                    "prior_weight": round(prior[name], 6),
+                    "raw_score": None,
+                    "final_weight": round(prior[name], 6),
+                    "edge_vs_persistence_mae_pct": None,
+                }
+                for name, metric in metrics.items()
+            },
+        }
+        return prior, diagnostics
+
+    persistence_mae = float(metrics["persistence"]["mae_pct"]) if "persistence" in metrics else None
+    raw_scores: dict[str, float] = {}
+    for name, metric in metrics.items():
+        mae = float(metric["mae_pct"])
+        direction_accuracy = float(metric["direction_accuracy"])
+        bias = abs(float(metric["mean_signed_error_pct"]))
+
+        score = math.exp(-ADAPTIVE_MAE_LAMBDA * mae)
+        score *= 1.0 + ADAPTIVE_DIRECTION_REWARD * (direction_accuracy - 0.5) * 2.0
+        score *= math.exp(-0.35 * bias)
+
+        if persistence_mae is not None and name != "persistence":
+            edge = persistence_mae - mae
+            if edge < 0:
+                score *= math.exp(1.5 * edge)
+
+        raw_scores[name] = max(score, 1e-9)
+
+    raw_total = sum(raw_scores.values())
+    adaptive = {name: score / raw_total for name, score in raw_scores.items()}
+
+    sample_count = min(int(metric["samples"]) for metric in metrics.values())
+    progress = min(
+        1.0,
+        max(
+            0.0,
+            (sample_count - ADAPTIVE_MIN_SAMPLES)
+            / max(1, ADAPTIVE_FULL_SAMPLES - ADAPTIVE_MIN_SAMPLES),
+        ),
+    )
+    blend = 0.25 + (ADAPTIVE_MAX_BLEND - 0.25) * progress
+
+    blended = {
+        name: (1.0 - blend) * prior[name] + blend * adaptive[name]
+        for name in model_names
+    }
+
+    complex_maes = [
+        float(metrics[name]["mae_pct"])
+        for name in model_names
+        if name != "persistence" and metrics[name]["mae_pct"] is not None
+    ]
+    persistence_fallback = False
+    if (
+        persistence_mae is not None
+        and complex_maes
+        and float(np.mean(complex_maes)) >= persistence_mae
+        and "persistence" in blended
+    ):
+        blended["persistence"] += PERSISTENCE_FALLBACK_BOOST
+        persistence_fallback = True
+
+    final = _bounded_normalize(blended)
+
+    diagnostics = {
+        "mode": "adaptive",
+        "source": source,
+        "horizon": f"{hour}h",
+        "regime": regime,
+        "blend_factor": round(blend, 4),
+        "sample_count": sample_count,
+        "persistence_fallback": persistence_fallback,
+        "persistence_mae_pct": round(persistence_mae, 6)
+        if persistence_mae is not None
+        else None,
+        "models": {},
+    }
+    for name, metric in metrics.items():
+        mae = float(metric["mae_pct"])
+        diagnostics["models"][name] = {
+            **{
+                key: round(value, 6) if isinstance(value, float) else value
+                for key, value in metric.items()
+            },
+            "prior_weight": round(prior[name], 6),
+            "raw_score": round(raw_scores[name], 8),
+            "adaptive_weight": round(adaptive[name], 6),
+            "final_weight": round(final[name], 6),
+            "edge_vs_persistence_mae_pct": (
+                round(persistence_mae - mae, 6)
+                if persistence_mae is not None
+                else None
+            ),
+        }
+
+    return final, diagnostics
 
 
 def empirical_calibration_multiplier(
@@ -311,14 +595,33 @@ def ensemble_forecast(
     model_predictions: dict[str, dict[str, dict[str, float]]],
     regime: str,
     calibration: dict[str, tuple[float, int, float | None]],
-) -> tuple[dict[str, dict[str, float]], dict[str, float]]:
+    history: list[dict[str, Any]],
+    actual_by_timestamp: dict[int, float],
+    adaptive_weights_enabled: bool = True,
+) -> tuple[
+    dict[str, dict[str, float | str]],
+    dict[str, dict[str, float]],
+    dict[str, dict[str, Any]],
+]:
     names = list(model_predictions)
-    weights = model_weights(names, regime)
     current_price = float(data.closes[-1])
-    predictions: dict[str, dict[str, float]] = {}
+    predictions: dict[str, dict[str, float | str]] = {}
+    weights_by_horizon: dict[str, dict[str, float]] = {}
+    weighting_diagnostics: dict[str, dict[str, Any]] = {}
 
     for hour in TARGET_HOURS:
         key = f"{hour}h"
+        weights, diagnostics = adaptive_model_weights(
+            names,
+            regime,
+            hour,
+            history,
+            actual_by_timestamp,
+            enabled=adaptive_weights_enabled,
+        )
+        weights_by_horizon[key] = weights
+        weighting_diagnostics[key] = diagnostics
+
         log_changes: list[float] = []
         model_prices: list[float] = []
         model_ws: list[float] = []
@@ -342,7 +645,9 @@ def ensemble_forecast(
         normalized /= normalized.sum()
         ensemble_log_change = float(np.dot(normalized, np.asarray(log_changes)))
         price = current_price * math.exp(ensemble_log_change)
-        dispersion = float(math.sqrt(np.dot(normalized, (np.asarray(model_prices) - price) ** 2)))
+        dispersion = float(
+            math.sqrt(np.dot(normalized, (np.asarray(model_prices) - price) ** 2))
+        )
         tf_width = float(np.mean(timesfm_half_widths)) if timesfm_half_widths else 0.0
         base_half_width = max(tf_width, dispersion * 1.5, current_price * 0.0005)
 
@@ -351,7 +656,10 @@ def ensemble_forecast(
         q10 = max(0.01, price - half_width)
         q90 = price + half_width
 
-        moves = [1 if p > current_price else -1 if p < current_price else 0 for p in model_prices]
+        moves = [
+            1 if p > current_price else -1 if p < current_price else 0
+            for p in model_prices
+        ]
         agreement = max(moves.count(1), moves.count(-1), moves.count(0)) / len(moves)
         predictions[key] = {
             "price_usd": round(price, 2),
@@ -360,6 +668,8 @@ def ensemble_forecast(
             "q50_usd": round(price, 2),
             "q90_usd": round(q90, 2),
             "model_agreement": round(agreement, 4),
+            "weighting_mode": str(diagnostics["mode"]),
+            "weighting_samples": int(diagnostics["sample_count"]),
             "interval_calibration_multiplier": round(multiplier, 4),
             "calibration_samples": sample_count,
             "empirical_q10_q90_coverage": (
@@ -367,13 +677,14 @@ def ensemble_forecast(
             ),
         }
 
-    return predictions, weights
+    return predictions, weights_by_horizon, weighting_diagnostics
 
 
 def build_forecast(
     model: TimesFM3Evaluator,
     data: MarketData,
     history: list[dict[str, Any]] | None = None,
+    adaptive_weights_enabled: bool = True,
 ) -> dict[str, Any]:
     history = history or []
     features = market_features(data)
@@ -385,16 +696,30 @@ def build_forecast(
         f"{hour}h": empirical_calibration_multiplier(history, actuals, hour)
         for hour in TARGET_HOURS
     }
-    predictions, weights = ensemble_forecast(data, models, regime, calibration)
+    predictions, weights, weighting_diagnostics = ensemble_forecast(
+        data,
+        models,
+        regime,
+        calibration,
+        history,
+        actuals,
+        adaptive_weights_enabled=adaptive_weights_enabled,
+    )
 
     return {
         "model": MODEL_ID,
-        "forecast_method": "log-return multi-context ensemble",
-        "latest_close_at": datetime.fromtimestamp(data.timestamps[-1], tz=timezone.utc).isoformat(),
+        "forecast_method": "log-return multi-context adaptive ensemble",
+        "latest_close_at": datetime.fromtimestamp(
+            data.timestamps[-1], tz=timezone.utc
+        ).isoformat(),
         "latest_close_usd": round(float(data.closes[-1]), 2),
         "market_features": features,
         "regime": regime,
-        "model_weights": {k: round(v, 4) for k, v in weights.items()},
+        "model_weights": {
+            horizon: {name: round(weight, 4) for name, weight in horizon_weights.items()}
+            for horizon, horizon_weights in weights.items()
+        },
+        "weighting_diagnostics": weighting_diagnostics,
         "model_predictions": {
             model_name: {
                 horizon: {

--- a/forecast_engine.py
+++ b/forecast_engine.py
@@ -53,6 +53,8 @@ class MarketData:
 
 
 def fetch_kraken_hourly(limit: int = 512) -> MarketData:
+    # N hourly returns require N+1 closes. Keep enough candles for the largest context.
+    limit = max(limit, max(CONTEXT_WINDOWS) + 1)
     response = requests.get(
         KRAKEN_OHLC_URL,
         params={"pair": PAIR, "interval": INTERVAL_MINUTES},

--- a/test_adaptive_weights.py
+++ b/test_adaptive_weights.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Unit tests for adaptive ensemble weighting."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from forecast_engine import (
+    ADAPTIVE_MAX_WEIGHT,
+    ADAPTIVE_MIN_WEIGHT,
+    _bounded_normalize,
+    adaptive_model_weights,
+    static_model_weights,
+)
+
+
+MODELS = ["timesfm_168h", "timesfm_336h", "persistence", "drift_7d", "ar1"]
+
+
+def snapshot(origin: datetime, current: float, actual: float) -> tuple[dict, int, float]:
+    predictions = {
+        "timesfm_168h": actual + 0.05,
+        "timesfm_336h": actual + 0.10,
+        "persistence": current,
+        "drift_7d": actual + 1.5,
+        "ar1": actual + 1.0,
+    }
+    item = {
+        "latest_close_at": origin.isoformat(),
+        "latest_close_usd": current,
+        "regime": "range",
+        "model_predictions": {
+            name: {"2h": {"price_usd": price}} for name, price in predictions.items()
+        },
+    }
+    return item, int((origin + timedelta(hours=2)).timestamp()), actual
+
+
+class AdaptiveWeightTests(unittest.TestCase):
+    def test_sparse_history_uses_static_prior(self) -> None:
+        prior = static_model_weights(MODELS, "range")
+        weights, diagnostics = adaptive_model_weights(MODELS, "range", 2, [], {})
+        self.assertEqual(diagnostics["mode"], "static_prior")
+        self.assertEqual(weights, prior)
+
+    def test_better_models_receive_more_weight(self) -> None:
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        history = []
+        actuals = {}
+        for i in range(12):
+            current = 100.0 + i
+            actual = current + 1.0
+            item, target, target_price = snapshot(start + timedelta(hours=2 * i), current, actual)
+            history.append(item)
+            actuals[target] = target_price
+
+        weights, diagnostics = adaptive_model_weights(MODELS, "range", 2, history, actuals)
+        self.assertEqual(diagnostics["mode"], "adaptive")
+        self.assertGreater(weights["timesfm_168h"], weights["drift_7d"])
+        self.assertGreater(weights["timesfm_336h"], weights["ar1"])
+
+    def test_weights_respect_bounds_and_sum_to_one(self) -> None:
+        weights = _bounded_normalize({"a": 100.0, "b": 1.0, "c": 1.0, "d": 1.0})
+        self.assertAlmostEqual(sum(weights.values()), 1.0, places=9)
+        for value in weights.values():
+            self.assertGreaterEqual(value, ADAPTIVE_MIN_WEIGHT - 1e-9)
+            self.assertLessEqual(value, ADAPTIVE_MAX_WEIGHT + 1e-9)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace one global static ensemble weight set with per-horizon adaptive weights
- learn from matured out-of-sample model performance using MAE %, direction accuracy, signed bias, and edge vs persistence
- prefer regime-specific history when enough samples exist, otherwise fall back to all recent regimes
- keep the existing regime weights as priors and fall back to them when history is sparse
- blend adaptation gradually, cap each model at 55%, and enforce a 3% minimum weight
- explicitly boost persistence when the complex models are collectively failing to beat it
- expose weighting mode, sample counts, per-model diagnostics, persistence edge, and final weights in `forecast.json`
- update the walk-forward backtest to compare the adaptive ensemble against the equivalent static ensemble and persistence
- add unit tests for sparse-history fallback, empirically better-model preference, normalization, and weight caps/floors
- document the adaptive algorithm and safeguards

## Safety / leakage controls
Only forecast targets already present in completed historical candles can influence weights. Future outcomes are never consulted. The adaptive distribution is blended with the static prior and never fully replaces it.

## Current history source
This implementation uses the existing rolling Actions forecast history immediately. Issue #5 remains the follow-up for moving the learning source to a durable long-term dataset, which will let the same algorithm train on a much larger sample.

## Files changed
- `forecast_engine.py`
- `backtest.py`
- `test_adaptive_weights.py`
- `README.md`

Related: #6