### PR TITLE
Persist long-term production forecast history

### DIFF
--- a/.github/workflows/forecast.yml
+++ b/.github/workflows/forecast.yml
@@ -14,7 +14,11 @@ on:
     - cron: "37 * * * *"
 
 permissions:
-  contents: read
+  # Read the source and update the dedicated forecast-history Release assets.
+  contents: write
+
+env:
+  HISTORY_RELEASE_TAG: forecast-history-v1
 
 concurrency:
   group: btc-timesfm-forecast
@@ -47,6 +51,26 @@ jobs:
           echo '## Forecast skipped' >> "$GITHUB_STEP_SUMMARY"
           echo '${{ steps.due.outputs.reason }}' >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Restore durable forecast database
+        if: steps.due.outputs.run_forecast == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p .state
+          if gh release view "$HISTORY_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release download "$HISTORY_RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern 'forecast_history.sqlite.gz' \
+              --dir .state
+            gzip -df .state/forecast_history.sqlite.gz
+            cp .state/forecast_history.sqlite .state/forecast_history.previous.sqlite
+            touch .state/history_restored_from_release
+            echo "Restored durable history from release $HISTORY_RELEASE_TAG"
+          else
+            echo "No durable history release exists yet; the first forecast will create it."
+          fi
+
       - name: Set up Python
         if: steps.due.outputs.run_forecast == 'true'
         uses: actions/setup-python@v5
@@ -69,7 +93,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Forecast BTC and score matured predictions
+      - name: Forecast BTC and persist matured predictions
         if: steps.due.outputs.run_forecast == 'true'
         run: python btc_forecast.py
 
@@ -77,12 +101,60 @@ jobs:
         if: steps.due.outputs.run_forecast == 'true'
         run: python format_tweet.py
 
+      - name: Verify and export durable history
+        if: steps.due.outputs.run_forecast == 'true'
+        run: |
+          set -euo pipefail
+          python history_store.py --db .state/forecast_history.sqlite verify
+          python history_store.py --db .state/forecast_history.sqlite export \
+            --format csv --output .state/forecast_history.csv
+          gzip -c .state/forecast_history.sqlite > .state/forecast_history.sqlite.gz
+          gzip -c .state/forecast_history.csv > .state/forecast_history.csv.gz
+          if [ -f .state/forecast_history.previous.sqlite ]; then
+            gzip -c .state/forecast_history.previous.sqlite \
+              > .state/forecast_history.previous.sqlite.gz
+          fi
+
+      - name: Publish durable forecast history
+        if: steps.due.outputs.run_forecast == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          assets=(
+            .state/forecast_history.sqlite.gz
+            .state/forecast_history.csv.gz
+          )
+          if [ -f .state/forecast_history.previous.sqlite.gz ]; then
+            assets+=(.state/forecast_history.previous.sqlite.gz)
+          fi
+
+          if [ -f .state/history_restored_from_release ]; then
+            # We only overwrite a release that was successfully restored in
+            # this same run. If restore failed transiently, this guard prevents
+            # a fresh empty database from clobbering an existing history.
+            gh release upload "$HISTORY_RELEASE_TAG" "${assets[@]}" \
+              --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            gh release create "$HISTORY_RELEASE_TAG" "${assets[@]}" \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
+              --title 'BTC forecast history datastore' \
+              --notes 'Machine-managed durable history for production BTC forecasts. Do not edit assets manually.' \
+              --latest=false
+          fi
+
       - name: Add forecast to job summary
         if: steps.due.outputs.run_forecast == 'true'
         run: |
           echo '## BTC TimesFM 3 forecast' >> "$GITHUB_STEP_SUMMARY"
           echo '```json' >> "$GITHUB_STEP_SUMMARY"
           cat forecast.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '## Durable history' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          python history_store.py --db .state/forecast_history.sqlite stats >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
           echo '' >> "$GITHUB_STEP_SUMMARY"
           echo '## X post' >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BTC Forecast Ensemble
 
-A BTC/USD forecasting experiment built around **TimesFM 3**, Kraken hourly candles, multiple baselines, regime detection, adaptive ensemble weighting, calibrated uncertainty and walk-forward backtesting.
+A BTC/USD forecasting experiment built around **TimesFM 3**, Kraken hourly candles, multiple baselines, regime detection, adaptive ensemble weighting, calibrated uncertainty, durable production history and walk-forward backtesting.
 
 ## What changed
 
@@ -17,6 +17,7 @@ The production forecast no longer feeds raw BTC prices into one TimesFM context.
 - evaluates 2h, 4h, 8h and 16h forecasts against the exact matching Kraken close
 - tracks MAE, signed bias, direction accuracy and interval coverage
 - stores per-model predictions so TimesFM can be compared directly with the simple baselines
+- persists every logical production forecast in a durable SQLite history database
 - includes a separate walk-forward backtesting workflow
 
 A second foundation model is intentionally not part of the scheduled ensemble yet: loading another large checkpoint every run would substantially increase GitHub Actions runtime. The architecture now makes it straightforward to add one later if backtests show it is worth the extra compute.
@@ -65,7 +66,7 @@ Those features classify the market as `range`, `trending` or `high_volatility`. 
 
 ## Adaptive ensemble weighting
 
-The ensemble no longer relies only on fixed hand-tuned weights. For each horizon independently, it scores matured historical predictions from every underlying model and adjusts the weights from measured out-of-sample performance.
+For each horizon independently, the ensemble scores matured historical predictions from every underlying model and adjusts weights from measured out-of-sample performance.
 
 The adaptive score uses:
 
@@ -94,7 +95,149 @@ weighting_diagnostics.<horizon>
 
 The diagnostics include static prior weight, recent sample count, MAE, direction accuracy, signed bias, raw adaptive score, learned weight, final weight, persistence edge, blend factor and whether the persistence fallback was activated.
 
-The current implementation learns from the rolling Actions forecast history. GitHub issue #5 tracks moving that learning history to a durable long-term dataset so adaptive weighting can eventually use substantially more observations.
+Production adaptive weighting now loads its snapshots from the durable SQLite history database. On the first run after this feature is deployed, the existing rolling Actions cache is migrated into SQLite so the observations already collected are not lost.
+
+## Durable production history
+
+`history_store.py` implements the long-term source of truth for production forecasts. The canonical database is:
+
+```text
+.state/forecast_history.sqlite
+```
+
+The database is **not committed to the source tree**. GitHub Actions compresses it and stores it in the dedicated GitHub Release tagged:
+
+```text
+forecast-history-v1
+```
+
+That Release contains:
+
+```text
+forecast_history.sqlite.gz           canonical current database
+forecast_history.csv.gz              denormalized analysis export
+forecast_history.previous.sqlite.gz  previous known-good database generation
+```
+
+The workflow uses only the repository `GITHUB_TOKEN`; no additional storage secret is required. The forecast job has `contents: write` solely so it can update these Release assets.
+
+### History schema
+
+SQLite schema version **1** uses two main tables:
+
+`forecast_origins` stores one row per completed source candle used as a forecast origin:
+
+```text
+origin_at
+generated_at
+source_name
+pair
+source_price_usd
+regime
+market_features_json
+first_seen_at
+last_seen_at
+```
+
+`forecast_predictions` stores one row per origin, model and horizon:
+
+```text
+origin_at
+model_name
+horizon_hours
+target_at
+predicted_price_usd
+predicted_change_pct
+q10_usd / q50_usd / q90_usd
+model_agreement
+ensemble_weight
+actual_target_price_usd
+absolute_error_usd
+absolute_error_pct
+signed_error_pct
+actual_change_pct
+direction_correct
+within_q10_q90
+matured_at
+```
+
+The logical primary key is:
+
+```text
+(origin_at, model_name, horizon_hours)
+```
+
+The ensemble itself is stored as model name `ensemble`, alongside `timesfm_168h`, `timesfm_336h`, `timesfm_512h`, `persistence`, `drift_7d` and `ar1` when those models are available.
+
+Schema versioning is recorded both in `PRAGMA user_version` and the `metadata` table. A database created by a newer unsupported schema is rejected rather than silently modified.
+
+### Append safety and manual reruns
+
+Forecast rows are **first-write-wins**. A manual rerun for the same source candle does not create a duplicate and does not rewrite the original prediction. It only updates the origin's `last_seen_at` timestamp and can fill outcomes that were previously missing.
+
+This is intentional: the historical dataset must preserve the forecast that was actually first observed, rather than allowing a later rerun to rewrite research history.
+
+The scheduled workflow also uses one concurrency group, so only one forecast job can update the Release-backed database at a time.
+
+### Outcome maturation
+
+Every production run compares all pending database rows with the completed Kraken candles currently available. A row matures only when the **exact target candle timestamp** exists.
+
+For a matured row the store persists:
+
+- actual target price
+- absolute USD and percentage error
+- signed error
+- actual percentage move
+- direction correctness
+- Q10-Q90 interval coverage when quantiles exist
+- maturation timestamp
+
+Outcomes are also write-once. Once an exact target candle has been persisted, a later run cannot overwrite it.
+
+Because the longest live horizon is 16h and Kraken exposes much more than 16 hours of recent OHLC data, normal scheduled operation has ample time to mature every prediction. If the workflow is disabled for an unusually long period, pending rows remain explicitly pending instead of being guessed from another exchange.
+
+### Query and export
+
+After obtaining the SQLite asset, analysis does not need to scrape Actions runs or artifacts.
+
+Verify and inspect the database:
+
+```bash
+python history_store.py --db forecast_history.sqlite verify
+python history_store.py --db forecast_history.sqlite stats
+python history_store.py --db forecast_history.sqlite summary
+```
+
+Export to CSV or JSON Lines:
+
+```bash
+python history_store.py --db forecast_history.sqlite export \
+  --format csv --output forecast_history.csv
+
+python history_store.py --db forecast_history.sqlite export \
+  --format jsonl --output forecast_history.jsonl
+```
+
+Download the current database with GitHub CLI:
+
+```bash
+gh release download forecast-history-v1 \
+  --pattern forecast_history.sqlite.gz
+gunzip forecast_history.sqlite.gz
+```
+
+The CSV export is also attached directly to the same Release for quick notebook/spreadsheet analysis.
+
+### Retention and recovery
+
+The `forecast-history-v1` Release is intended to be retained indefinitely. At the current forecast cadence the normalized SQLite database remains small; the project can rotate to a new history release/version if it eventually becomes operationally large.
+
+Before each mutation, the workflow keeps the successfully restored database as `forecast_history.previous.sqlite.gz`. The new database is verified with SQLite integrity and foreign-key checks before it is uploaded. If the current asset is damaged, the previous asset is therefore a one-generation recovery point.
+
+The workflow will only overwrite an existing Release when that same run successfully restored it first. This prevents a transient download/authentication failure from replacing the real dataset with a newly initialized empty database.
+
+The small `.state/previous_forecast.json` Actions cache remains in place for fast scheduler decisions. It is not the long-term source of truth, but it also provides a bootstrap source for recent forecasts if the durable database is being created for the first time.
 
 ## Confidence and uncertainty
 
@@ -104,9 +247,9 @@ The TimesFM quantile paths provide the starting uncertainty band. The band is wi
 
 ## Reliability metrics
 
-The rolling history stores up to 72 snapshots. Matured predictions are matched to the exact Kraken hourly close at their target timestamp.
+Matured predictions are matched to the exact Kraken hourly close at their target timestamp.
 
-For each horizon the project tracks absolute USD error, MAE %, signed error/bias, predicted vs actual change, direction accuracy, Q10-Q90 coverage and per-model performance. `forecast.json` also includes an aggregate `performance_summary` from the history currently available.
+For each horizon the project tracks absolute USD error, MAE %, signed error/bias, predicted vs actual change, direction accuracy, Q10-Q90 coverage and per-model performance. `forecast.json` includes an aggregate `performance_summary` backed by the durable database once matured records exist.
 
 ## Schedule
 
@@ -117,7 +260,9 @@ schedule:
   - cron: "37 * * * *"
 ```
 
-A lightweight guard restores forecast state first. The expensive forecast only runs after at least two completed candle-hours have elapsed since the previous saved forecast. This gives GitHub another opportunity every hour if a scheduled event is delayed or dropped while still producing roughly one forecast every two hours.
+A lightweight guard restores the rolling scheduler state first. The expensive forecast only runs after at least two completed candle-hours have elapsed since the previous saved forecast. This gives GitHub another opportunity every hour if a scheduled event is delayed or dropped while still producing roughly one forecast every two hours.
+
+When a forecast is due, the durable Release database is restored before model execution, updated and verified after the forecast, and published back before any X post is sent.
 
 Scheduled forecasts post to X automatically. Manual runs only post when `post_to_x=true`.
 
@@ -129,7 +274,7 @@ Twikit is an unofficial X client and can break when X changes its internal front
 
 ## Backtesting
 
-`backtest.py` performs walk-forward historical forecasts and now compares the **adaptive ensemble**, the equivalent **static-prior ensemble**, persistence, each TimesFM context and the other simple baselines.
+`backtest.py` performs walk-forward historical forecasts and compares the **adaptive ensemble**, the equivalent **static-prior ensemble**, persistence, each TimesFM context and the other simple baselines.
 
 The manual **BTC Forecast Backtest** GitHub workflow defaults to 90 days of history and 60 walk-forward samples.
 
@@ -149,17 +294,20 @@ The most important comparisons are whether the adaptive ensemble beats the stati
 
 ## Tests
 
-Adaptive-weight safeguards have unit coverage for sparse-history fallback, favoring empirically better models, normalization and per-model weight floors/caps:
+Run the complete unit-test suite:
 
 ```bash
-python -m unittest test_adaptive_weights.py
+pip install -r requirements-test.txt
+python -m unittest discover -s . -p 'test_*.py' -v
 ```
+
+The history-store tests cover schema verification, idempotent manual reruns, first-write-wins predictions, exact-target maturation, write-once outcomes, rolling-cache migration, adaptive-history reconstruction and CSV/JSONL export.
 
 ## Production output
 
-`forecast.json` contains the latest BTC/USD close, market features, regime, per-horizon adaptive model weights, weighting diagnostics, per-model forecasts, ensemble 2h/4h/8h/16h forecasts, model agreement, calibrated uncertainty, latest matured reliability and rolling performance summary.
+`forecast.json` contains the latest BTC/USD close, market features, regime, per-horizon adaptive model weights, weighting diagnostics, per-model forecasts, ensemble 2h/4h/8h/16h forecasts, model agreement, calibrated uncertainty, latest matured reliability, durable performance summary and `history_store` statistics.
 
-Forecast history lives in `.state/previous_forecast.json` and is persisted with the GitHub Actions cache rather than committed to the repository.
+The durable history lives in the `forecast-history-v1` GitHub Release. `.state/previous_forecast.json` remains only as a small rolling scheduler cache.
 
 ## Run locally
 
@@ -169,7 +317,7 @@ Python 3.11:
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-python -m unittest test_adaptive_weights.py
+python -m unittest discover -s . -p 'test_*.py' -v
 python btc_forecast.py
 ```
 

--- a/btc_forecast.py
+++ b/btc_forecast.py
@@ -11,11 +11,13 @@ from typing import Any
 import numpy as np
 
 from forecast_engine import TARGET_HOURS, build_forecast, fetch_kraken_hourly, load_timesfm
+from history_store import DEFAULT_DB_PATH, ForecastHistoryStore
 
 
 OUTPUT_PATH = Path("forecast.json")
 TWEET_PATH = Path("tweet.txt")
 STATE_PATH = Path(".state/previous_forecast.json")
+HISTORY_DB_PATH = DEFAULT_DB_PATH
 HISTORY_LIMIT = 72
 
 
@@ -182,10 +184,13 @@ def performance_summary(
 
 
 def save_forecast_history(history: list[dict[str, Any]], output: dict[str, Any]) -> None:
+    """Keep a small rolling cache for the scheduler; durable data lives in SQLite."""
     snapshot = {
         "generated_at": output["generated_at"],
         "latest_close_at": output["latest_close_at"],
         "latest_close_usd": output["latest_close_usd"],
+        "source": output.get("source"),
+        "pair": output.get("pair"),
         "regime": output["regime"],
         "market_features": output["market_features"],
         "model_weights": output["model_weights"],
@@ -267,9 +272,21 @@ def main() -> None:
         f"{datetime.fromtimestamp(data.timestamps[-1], tz=timezone.utc).isoformat()}"
     )
 
-    history = load_forecast_history()
+    actuals = dict(zip(data.timestamps, map(float, data.closes), strict=True))
+    rolling_history = load_forecast_history()
+
+    # Bootstrap/migrate the durable database from any rolling cache that predates
+    # issue #5, then use the durable copy as the source of truth for weighting.
+    store = ForecastHistoryStore(HISTORY_DB_PATH)
+    migration = store.ingest_snapshots(rolling_history, actuals)
+    durable_history = store.load_snapshots()
+    history = durable_history or rolling_history
+
     reliability = score_forecast_history(history, data.closes, data.timestamps)
-    summary = performance_summary(history, data.closes, data.timestamps)
+    summary = store.performance_summary()
+    if not summary:
+        # Local/first-run fallback before any matured durable records exist.
+        summary = performance_summary(history, data.closes, data.timestamps)
 
     model = load_timesfm()
     engine_output = build_forecast(model, data, history)
@@ -283,13 +300,24 @@ def main() -> None:
         "previous_forecast_reliability": reliability.get("2h"),
     }
 
+    # The scheduler still gets a tiny fast cache, while the SQLite store keeps
+    # every logical forecast indefinitely and matures any exact target candles.
+    save_forecast_history(rolling_history, output)
+    persisted = store.ingest_snapshot(output, actuals)
+    store.verify()
+    output["history_store"] = {
+        **store.stats(),
+        "rolling_cache_migration": migration,
+        "latest_ingest": persisted,
+    }
+
     OUTPUT_PATH.write_text(json.dumps(output, indent=2) + "\n")
-    save_forecast_history(history, output)
     tweet = build_tweet(output)
     TWEET_PATH.write_text(tweet + "\n")
 
     print(f"\nRegime: {output['regime']}")
     print(f"Model weights: {output['model_weights']}")
+    print(f"Durable history: {output['history_store']}")
     print("\nBTC/USD ensemble forecast")
     print("-" * 78)
     print(f"{'Horizon':<9}{'Forecast':>16}{'Change':>12}{'Q10':>16}{'Q90':>16}{'Agree':>9}")

--- a/history_store.py
+++ b/history_store.py
@@ -1,0 +1,654 @@
+#!/usr/bin/env python3
+"""Durable forecast-history storage and analysis helpers.
+
+The production workflow keeps this SQLite database as a compressed GitHub
+Release asset. Forecasts are immutable by logical key (origin, model, horizon),
+so manual reruns cannot rewrite the prediction that was first observed. Outcome
+fields are filled later when the exact target Kraken candle is available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable, TextIO
+
+
+SCHEMA_VERSION = 1
+DEFAULT_DB_PATH = Path(".state/forecast_history.sqlite")
+ENSEMBLE_MODEL = "ensemble"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_timestamp(value: Any) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise ValueError("timestamp must be a non-empty string")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _direction(value: float, epsilon: float = 1e-9) -> int:
+    return 1 if value > epsilon else -1 if value < -epsilon else 0
+
+
+def _horizon_hours(key: str) -> int | None:
+    if not isinstance(key, str) or not key.endswith("h"):
+        return None
+    try:
+        value = int(key[:-1])
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _model_weight(snapshot: dict[str, Any], model_name: str, horizon: str) -> float | None:
+    weights = snapshot.get("model_weights")
+    if not isinstance(weights, dict):
+        return None
+
+    # Current format: model_weights.<horizon>.<model>.
+    horizon_weights = weights.get(horizon)
+    if isinstance(horizon_weights, dict):
+        return _optional_float(horizon_weights.get(model_name))
+
+    # Older static-ensemble snapshots stored one global model-weight mapping.
+    return _optional_float(weights.get(model_name))
+
+
+def _prediction_rows(snapshot: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    origin = _parse_timestamp(snapshot["latest_close_at"])
+    source_price = float(snapshot["latest_close_usd"])
+
+    ensemble_predictions = snapshot.get("predictions", {})
+    if isinstance(ensemble_predictions, dict):
+        for horizon, item in ensemble_predictions.items():
+            hour = _horizon_hours(horizon)
+            if hour is None or not isinstance(item, dict) or "price_usd" not in item:
+                continue
+            predicted = float(item["price_usd"])
+            yield {
+                "model_name": ENSEMBLE_MODEL,
+                "horizon_hours": hour,
+                "target_at": _iso(origin + timedelta(hours=hour)),
+                "predicted_price_usd": predicted,
+                "predicted_change_pct": float(
+                    item.get("change_pct", (predicted / source_price - 1.0) * 100.0)
+                ),
+                "q10_usd": _optional_float(item.get("q10_usd")),
+                "q50_usd": _optional_float(item.get("q50_usd")),
+                "q90_usd": _optional_float(item.get("q90_usd")),
+                "model_agreement": _optional_float(item.get("model_agreement")),
+                "ensemble_weight": None,
+            }
+
+    model_predictions = snapshot.get("model_predictions", {})
+    if not isinstance(model_predictions, dict):
+        return
+
+    for model_name, horizons in model_predictions.items():
+        if not isinstance(model_name, str) or not isinstance(horizons, dict):
+            continue
+        for horizon, item in horizons.items():
+            hour = _horizon_hours(horizon)
+            if hour is None or not isinstance(item, dict) or "price_usd" not in item:
+                continue
+            predicted = float(item["price_usd"])
+            yield {
+                "model_name": model_name,
+                "horizon_hours": hour,
+                "target_at": _iso(origin + timedelta(hours=hour)),
+                "predicted_price_usd": predicted,
+                "predicted_change_pct": (predicted / source_price - 1.0) * 100.0,
+                "q10_usd": _optional_float(item.get("q10_usd")),
+                "q50_usd": _optional_float(item.get("q50_usd")),
+                "q90_usd": _optional_float(item.get("q90_usd")),
+                "model_agreement": None,
+                "ensemble_weight": _model_weight(snapshot, model_name, horizon),
+            }
+
+
+class ForecastHistoryStore:
+    """SQLite-backed append-safe store for production forecasts and outcomes."""
+
+    def __init__(self, path: Path | str = DEFAULT_DB_PATH) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.path)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON")
+        connection.execute("PRAGMA journal_mode = DELETE")
+        return connection
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+            if version > SCHEMA_VERSION:
+                raise RuntimeError(
+                    f"History database schema {version} is newer than supported {SCHEMA_VERSION}"
+                )
+
+            connection.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS metadata (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS forecast_origins (
+                    origin_at TEXT PRIMARY KEY,
+                    generated_at TEXT NOT NULL,
+                    source_name TEXT,
+                    pair TEXT,
+                    source_price_usd REAL NOT NULL,
+                    regime TEXT,
+                    market_features_json TEXT NOT NULL,
+                    first_seen_at TEXT NOT NULL,
+                    last_seen_at TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS forecast_predictions (
+                    origin_at TEXT NOT NULL,
+                    model_name TEXT NOT NULL,
+                    horizon_hours INTEGER NOT NULL CHECK (horizon_hours > 0),
+                    target_at TEXT NOT NULL,
+                    predicted_price_usd REAL NOT NULL,
+                    predicted_change_pct REAL NOT NULL,
+                    q10_usd REAL,
+                    q50_usd REAL,
+                    q90_usd REAL,
+                    model_agreement REAL,
+                    ensemble_weight REAL,
+                    actual_target_price_usd REAL,
+                    absolute_error_usd REAL,
+                    absolute_error_pct REAL,
+                    signed_error_pct REAL,
+                    actual_change_pct REAL,
+                    direction_correct INTEGER,
+                    within_q10_q90 INTEGER,
+                    matured_at TEXT,
+                    PRIMARY KEY (origin_at, model_name, horizon_hours),
+                    FOREIGN KEY (origin_at) REFERENCES forecast_origins(origin_at)
+                        ON DELETE CASCADE
+                );
+
+                CREATE INDEX IF NOT EXISTS idx_predictions_target_pending
+                    ON forecast_predictions(target_at, actual_target_price_usd);
+                CREATE INDEX IF NOT EXISTS idx_predictions_model_horizon
+                    ON forecast_predictions(model_name, horizon_hours);
+                """
+            )
+            connection.execute(
+                "INSERT OR REPLACE INTO metadata(key, value) VALUES('schema_version', ?)",
+                (str(SCHEMA_VERSION),),
+            )
+            connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+
+    def ingest_snapshot(
+        self,
+        snapshot: dict[str, Any],
+        actual_by_timestamp: dict[int, float] | None = None,
+    ) -> dict[str, int]:
+        """Insert one logical forecast without rewriting an existing prediction.
+
+        The first prediction for a given (origin, model, horizon) wins. A manual
+        rerun of the same source candle only updates last_seen_at and can enrich
+        missing outcomes; it cannot silently alter the historical forecast.
+        """
+        origin = _parse_timestamp(snapshot["latest_close_at"])
+        origin_at = _iso(origin)
+        generated_at = _iso(
+            _parse_timestamp(str(snapshot.get("generated_at") or snapshot["latest_close_at"]))
+        )
+        source_price = float(snapshot["latest_close_usd"])
+        now = _iso(_utc_now())
+        market_features = snapshot.get("market_features", {})
+        if not isinstance(market_features, dict):
+            market_features = {}
+
+        prediction_rows = list(_prediction_rows(snapshot))
+        inserted_origins = 0
+        inserted_predictions = 0
+
+        with self._connect() as connection:
+            cursor = connection.execute(
+                """
+                INSERT OR IGNORE INTO forecast_origins(
+                    origin_at, generated_at, source_name, pair, source_price_usd,
+                    regime, market_features_json, first_seen_at, last_seen_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    origin_at,
+                    generated_at,
+                    snapshot.get("source"),
+                    snapshot.get("pair"),
+                    source_price,
+                    snapshot.get("regime"),
+                    json.dumps(market_features, sort_keys=True, separators=(",", ":")),
+                    now,
+                    now,
+                ),
+            )
+            inserted_origins += cursor.rowcount
+            connection.execute(
+                "UPDATE forecast_origins SET last_seen_at = ? WHERE origin_at = ?",
+                (now, origin_at),
+            )
+
+            for row in prediction_rows:
+                cursor = connection.execute(
+                    """
+                    INSERT OR IGNORE INTO forecast_predictions(
+                        origin_at, model_name, horizon_hours, target_at,
+                        predicted_price_usd, predicted_change_pct,
+                        q10_usd, q50_usd, q90_usd,
+                        model_agreement, ensemble_weight
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        origin_at,
+                        row["model_name"],
+                        row["horizon_hours"],
+                        row["target_at"],
+                        row["predicted_price_usd"],
+                        row["predicted_change_pct"],
+                        row["q10_usd"],
+                        row["q50_usd"],
+                        row["q90_usd"],
+                        row["model_agreement"],
+                        row["ensemble_weight"],
+                    ),
+                )
+                inserted_predictions += cursor.rowcount
+
+        matured = self.enrich_outcomes(actual_by_timestamp or {})
+        return {
+            "origins_inserted": inserted_origins,
+            "predictions_inserted": inserted_predictions,
+            "outcomes_matured": matured,
+        }
+
+    def ingest_snapshots(
+        self,
+        snapshots: Iterable[dict[str, Any]],
+        actual_by_timestamp: dict[int, float] | None = None,
+    ) -> dict[str, int]:
+        totals = {"origins_inserted": 0, "predictions_inserted": 0, "outcomes_matured": 0}
+        for snapshot in snapshots:
+            if not isinstance(snapshot, dict):
+                continue
+            try:
+                result = self.ingest_snapshot(snapshot)
+            except (KeyError, TypeError, ValueError):
+                continue
+            totals["origins_inserted"] += result["origins_inserted"]
+            totals["predictions_inserted"] += result["predictions_inserted"]
+        totals["outcomes_matured"] = self.enrich_outcomes(actual_by_timestamp or {})
+        return totals
+
+    def enrich_outcomes(self, actual_by_timestamp: dict[int, float]) -> int:
+        """Fill outcomes for every pending row whose exact target candle exists."""
+        if not actual_by_timestamp:
+            return 0
+
+        matured = 0
+        now = _iso(_utc_now())
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT p.origin_at, p.model_name, p.horizon_hours, p.target_at,
+                       p.predicted_price_usd, p.q10_usd, p.q90_usd,
+                       o.source_price_usd
+                FROM forecast_predictions AS p
+                JOIN forecast_origins AS o USING(origin_at)
+                WHERE p.actual_target_price_usd IS NULL
+                ORDER BY p.target_at
+                """
+            ).fetchall()
+
+            for row in rows:
+                target_timestamp = int(_parse_timestamp(row["target_at"]).timestamp())
+                actual = actual_by_timestamp.get(target_timestamp)
+                if actual is None or float(actual) <= 0:
+                    continue
+                actual = float(actual)
+                predicted = float(row["predicted_price_usd"])
+                source_price = float(row["source_price_usd"])
+                error = predicted - actual
+                q10 = _optional_float(row["q10_usd"])
+                q90 = _optional_float(row["q90_usd"])
+                within_interval = (
+                    int(q10 <= actual <= q90) if q10 is not None and q90 is not None else None
+                )
+
+                cursor = connection.execute(
+                    """
+                    UPDATE forecast_predictions
+                    SET actual_target_price_usd = ?,
+                        absolute_error_usd = ?,
+                        absolute_error_pct = ?,
+                        signed_error_pct = ?,
+                        actual_change_pct = ?,
+                        direction_correct = ?,
+                        within_q10_q90 = ?,
+                        matured_at = ?
+                    WHERE origin_at = ? AND model_name = ? AND horizon_hours = ?
+                      AND actual_target_price_usd IS NULL
+                    """,
+                    (
+                        actual,
+                        abs(error),
+                        abs(error) / actual * 100.0,
+                        error / actual * 100.0,
+                        (actual / source_price - 1.0) * 100.0,
+                        int(
+                            _direction(predicted - source_price)
+                            == _direction(actual - source_price)
+                        ),
+                        within_interval,
+                        now,
+                        row["origin_at"],
+                        row["model_name"],
+                        row["horizon_hours"],
+                    ),
+                )
+                matured += cursor.rowcount
+        return matured
+
+    def load_snapshots(self, limit: int | None = None) -> list[dict[str, Any]]:
+        """Reconstruct forecast snapshots for adaptive weighting/calibration code."""
+        with self._connect() as connection:
+            if limit is None:
+                origins = connection.execute(
+                    "SELECT * FROM forecast_origins ORDER BY origin_at"
+                ).fetchall()
+            else:
+                origins = connection.execute(
+                    "SELECT * FROM forecast_origins ORDER BY origin_at DESC LIMIT ?",
+                    (max(0, int(limit)),),
+                ).fetchall()[::-1]
+
+            snapshots: list[dict[str, Any]] = []
+            for origin in origins:
+                try:
+                    market_features = json.loads(origin["market_features_json"])
+                except (json.JSONDecodeError, TypeError):
+                    market_features = {}
+                snapshot: dict[str, Any] = {
+                    "generated_at": origin["generated_at"],
+                    "latest_close_at": origin["origin_at"],
+                    "latest_close_usd": float(origin["source_price_usd"]),
+                    "source": origin["source_name"],
+                    "pair": origin["pair"],
+                    "regime": origin["regime"],
+                    "market_features": market_features,
+                    "model_weights": {},
+                    "model_predictions": {},
+                    "predictions": {},
+                }
+
+                predictions = connection.execute(
+                    """
+                    SELECT * FROM forecast_predictions
+                    WHERE origin_at = ?
+                    ORDER BY horizon_hours, model_name
+                    """,
+                    (origin["origin_at"],),
+                ).fetchall()
+                for row in predictions:
+                    horizon = f"{int(row['horizon_hours'])}h"
+                    item: dict[str, Any] = {
+                        "price_usd": float(row["predicted_price_usd"]),
+                    }
+                    for column in ("q10_usd", "q50_usd", "q90_usd"):
+                        if row[column] is not None:
+                            item[column] = float(row[column])
+
+                    if row["model_name"] == ENSEMBLE_MODEL:
+                        item["change_pct"] = float(row["predicted_change_pct"])
+                        if row["model_agreement"] is not None:
+                            item["model_agreement"] = float(row["model_agreement"])
+                        snapshot["predictions"][horizon] = item
+                    else:
+                        model_name = str(row["model_name"])
+                        snapshot["model_predictions"].setdefault(model_name, {})[horizon] = item
+                        if row["ensemble_weight"] is not None:
+                            snapshot["model_weights"].setdefault(horizon, {})[model_name] = float(
+                                row["ensemble_weight"]
+                            )
+                snapshots.append(snapshot)
+            return snapshots
+
+    def stats(self) -> dict[str, Any]:
+        with self._connect() as connection:
+            origins = int(connection.execute("SELECT COUNT(*) FROM forecast_origins").fetchone()[0])
+            predictions = int(
+                connection.execute("SELECT COUNT(*) FROM forecast_predictions").fetchone()[0]
+            )
+            matured = int(
+                connection.execute(
+                    "SELECT COUNT(*) FROM forecast_predictions WHERE actual_target_price_usd IS NOT NULL"
+                ).fetchone()[0]
+            )
+            first_last = connection.execute(
+                "SELECT MIN(origin_at), MAX(origin_at) FROM forecast_origins"
+            ).fetchone()
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "origins": origins,
+            "predictions": predictions,
+            "matured_predictions": matured,
+            "pending_predictions": predictions - matured,
+            "first_origin_at": first_last[0],
+            "latest_origin_at": first_last[1],
+            "database_bytes": self.path.stat().st_size if self.path.exists() else 0,
+        }
+
+    def performance_summary(self) -> dict[str, Any]:
+        """Return all-time matured metrics in the same shape used by forecast.json."""
+        with self._connect() as connection:
+            horizons = [
+                int(row[0])
+                for row in connection.execute(
+                    """
+                    SELECT DISTINCT horizon_hours FROM forecast_predictions
+                    WHERE actual_target_price_usd IS NOT NULL
+                    ORDER BY horizon_hours
+                    """
+                ).fetchall()
+            ]
+            result: dict[str, Any] = {}
+            for hour in horizons:
+                metrics = connection.execute(
+                    """
+                    SELECT model_name,
+                           COUNT(*) AS samples,
+                           AVG(absolute_error_pct) AS mae_pct,
+                           AVG(signed_error_pct) AS signed_error_pct,
+                           AVG(direction_correct) AS direction_accuracy,
+                           AVG(within_q10_q90) AS interval_coverage
+                    FROM forecast_predictions
+                    WHERE horizon_hours = ? AND actual_target_price_usd IS NOT NULL
+                    GROUP BY model_name
+                    ORDER BY model_name
+                    """,
+                    (hour,),
+                ).fetchall()
+                by_model = {str(row["model_name"]): row for row in metrics}
+                ensemble = by_model.get(ENSEMBLE_MODEL)
+                if ensemble is None:
+                    continue
+                models: dict[str, Any] = {}
+                for name, row in by_model.items():
+                    if name == ENSEMBLE_MODEL:
+                        continue
+                    models[name] = {
+                        "samples": int(row["samples"]),
+                        "mae_pct": round(float(row["mae_pct"]), 4),
+                        "mean_signed_error_pct": round(float(row["signed_error_pct"]), 4),
+                        "direction_accuracy": round(float(row["direction_accuracy"]), 4),
+                    }
+                result[f"{hour}h"] = {
+                    "samples": int(ensemble["samples"]),
+                    "mae_pct": round(float(ensemble["mae_pct"]), 4),
+                    "mean_signed_error_pct": round(float(ensemble["signed_error_pct"]), 4),
+                    "direction_accuracy": round(float(ensemble["direction_accuracy"]), 4),
+                    "q10_q90_coverage": (
+                        round(float(ensemble["interval_coverage"]), 4)
+                        if ensemble["interval_coverage"] is not None
+                        else None
+                    ),
+                    "models": models,
+                }
+            return result
+
+    def verify(self) -> dict[str, Any]:
+        with self._connect() as connection:
+            integrity = str(connection.execute("PRAGMA integrity_check").fetchone()[0])
+            foreign_keys = connection.execute("PRAGMA foreign_key_check").fetchall()
+            version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if integrity != "ok":
+            raise RuntimeError(f"SQLite integrity check failed: {integrity}")
+        if foreign_keys:
+            raise RuntimeError(f"SQLite foreign-key check failed: {len(foreign_keys)} violation(s)")
+        if version != SCHEMA_VERSION:
+            raise RuntimeError(
+                f"Unexpected schema version {version}; expected {SCHEMA_VERSION}"
+            )
+        return {"integrity": integrity, "foreign_key_violations": 0, "schema_version": version}
+
+    def export_rows(self) -> list[dict[str, Any]]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT o.generated_at,
+                       o.origin_at,
+                       o.source_name,
+                       o.pair,
+                       o.source_price_usd,
+                       o.regime,
+                       o.market_features_json,
+                       p.model_name,
+                       p.horizon_hours,
+                       p.target_at,
+                       p.predicted_price_usd,
+                       p.predicted_change_pct,
+                       p.q10_usd,
+                       p.q50_usd,
+                       p.q90_usd,
+                       p.model_agreement,
+                       p.ensemble_weight,
+                       p.actual_target_price_usd,
+                       p.absolute_error_usd,
+                       p.absolute_error_pct,
+                       p.signed_error_pct,
+                       p.actual_change_pct,
+                       p.direction_correct,
+                       p.within_q10_q90,
+                       p.matured_at
+                FROM forecast_predictions AS p
+                JOIN forecast_origins AS o USING(origin_at)
+                ORDER BY o.origin_at, p.horizon_hours, p.model_name
+                """
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def export(self, output: Path | str, format_name: str = "csv") -> int:
+        rows = self.export_rows()
+        output_path = Path(output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        if format_name == "csv":
+            with output_path.open("w", encoding="utf-8", newline="") as handle:
+                if rows:
+                    writer = csv.DictWriter(handle, fieldnames=list(rows[0]))
+                    writer.writeheader()
+                    writer.writerows(rows)
+                else:
+                    handle.write("")
+        elif format_name == "jsonl":
+            with output_path.open("w", encoding="utf-8") as handle:
+                for row in rows:
+                    handle.write(json.dumps(row, sort_keys=True) + "\n")
+        else:
+            raise ValueError(f"Unsupported export format: {format_name}")
+        return len(rows)
+
+
+def _load_state(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, dict) and isinstance(payload.get("forecasts"), list):
+        return [item for item in payload["forecasts"] if isinstance(item, dict)]
+    if isinstance(payload, dict) and "predictions" in payload:
+        return [payload]
+    raise ValueError("State file does not contain forecast snapshots")
+
+
+def _write_json(data: Any, stream: TextIO = sys.stdout) -> None:
+    json.dump(data, stream, indent=2, sort_keys=True)
+    stream.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Inspect/export the durable BTC forecast history")
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("init")
+    subparsers.add_parser("verify")
+    subparsers.add_parser("stats")
+    subparsers.add_parser("summary")
+
+    ingest = subparsers.add_parser("ingest-state")
+    ingest.add_argument("--state", type=Path, required=True)
+
+    export = subparsers.add_parser("export")
+    export.add_argument("--format", choices=("csv", "jsonl"), default="csv")
+    export.add_argument("--output", type=Path, required=True)
+
+    args = parser.parse_args()
+    store = ForecastHistoryStore(args.db)
+
+    if args.command == "init":
+        _write_json(store.stats())
+    elif args.command == "verify":
+        _write_json(store.verify())
+    elif args.command == "stats":
+        _write_json(store.stats())
+    elif args.command == "summary":
+        _write_json(store.performance_summary())
+    elif args.command == "ingest-state":
+        result = store.ingest_snapshots(_load_state(args.state))
+        _write_json({**result, **store.stats()})
+    elif args.command == "export":
+        rows = store.export(args.output, args.format)
+        _write_json({"rows": rows, "format": args.format, "output": str(args.output)})
+
+
+if __name__ == "__main__":
+    main()

--- a/test_history_store.py
+++ b/test_history_store.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Unit tests for the durable SQLite forecast history store."""
+
+from __future__ import annotations
+
+import csv
+import json
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from history_store import ENSEMBLE_MODEL, ForecastHistoryStore, SCHEMA_VERSION
+
+
+def make_snapshot(
+    origin: datetime,
+    *,
+    generated_offset_minutes: int = 2,
+    source_price: float = 100.0,
+    ensemble_2h: float = 102.0,
+    regime: str = "range",
+) -> dict:
+    return {
+        "generated_at": (origin + timedelta(minutes=generated_offset_minutes)).isoformat(),
+        "latest_close_at": origin.isoformat(),
+        "latest_close_usd": source_price,
+        "source": "Kraken hourly OHLC",
+        "pair": "BTC/USD",
+        "regime": regime,
+        "market_features": {"rsi_14": 55.0, "volatility_24h_pct": 0.8},
+        "model_weights": {
+            "2h": {"timesfm_168h": 0.6, "persistence": 0.4},
+            "4h": {"timesfm_168h": 0.55, "persistence": 0.45},
+        },
+        "model_predictions": {
+            "timesfm_168h": {
+                "2h": {"price_usd": 103.0, "q10_usd": 98.0, "q50_usd": 102.0, "q90_usd": 106.0},
+                "4h": {"price_usd": 104.0, "q10_usd": 97.0, "q50_usd": 103.0, "q90_usd": 108.0},
+            },
+            "persistence": {
+                "2h": {"price_usd": source_price},
+                "4h": {"price_usd": source_price},
+            },
+        },
+        "predictions": {
+            "2h": {
+                "price_usd": ensemble_2h,
+                "change_pct": (ensemble_2h / source_price - 1.0) * 100.0,
+                "q10_usd": 98.0,
+                "q50_usd": ensemble_2h,
+                "q90_usd": 106.0,
+                "model_agreement": 0.75,
+            },
+            "4h": {
+                "price_usd": 103.0,
+                "change_pct": 3.0,
+                "q10_usd": 97.0,
+                "q50_usd": 103.0,
+                "q90_usd": 108.0,
+                "model_agreement": 0.75,
+            },
+        },
+    }
+
+
+class HistoryStoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.tmp.name) / "forecast_history.sqlite"
+        self.store = ForecastHistoryStore(self.db_path)
+        self.origin = datetime(2026, 1, 1, 12, tzinfo=timezone.utc)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_schema_is_versioned_and_verifiable(self) -> None:
+        verification = self.store.verify()
+        self.assertEqual(verification["schema_version"], SCHEMA_VERSION)
+        self.assertEqual(verification["integrity"], "ok")
+        with sqlite3.connect(self.db_path) as connection:
+            self.assertEqual(connection.execute("PRAGMA user_version").fetchone()[0], SCHEMA_VERSION)
+
+    def test_snapshot_creates_ensemble_and_model_rows(self) -> None:
+        result = self.store.ingest_snapshot(make_snapshot(self.origin))
+        self.assertEqual(result["origins_inserted"], 1)
+        # 2 horizons x (ensemble + two underlying models)
+        self.assertEqual(result["predictions_inserted"], 6)
+
+        rows = self.store.export_rows()
+        self.assertEqual(len(rows), 6)
+        self.assertEqual({row["model_name"] for row in rows}, {ENSEMBLE_MODEL, "timesfm_168h", "persistence"})
+        timesfm = next(
+            row for row in rows if row["model_name"] == "timesfm_168h" and row["horizon_hours"] == 2
+        )
+        self.assertAlmostEqual(timesfm["ensemble_weight"], 0.6)
+        ensemble = next(
+            row for row in rows if row["model_name"] == ENSEMBLE_MODEL and row["horizon_hours"] == 2
+        )
+        self.assertAlmostEqual(ensemble["model_agreement"], 0.75)
+        self.assertEqual(json.loads(ensemble["market_features_json"])["rsi_14"], 55.0)
+
+    def test_duplicate_origin_is_idempotent_and_preserves_first_prediction(self) -> None:
+        first = make_snapshot(self.origin, ensemble_2h=102.0)
+        rerun = make_snapshot(self.origin, generated_offset_minutes=20, ensemble_2h=150.0)
+        self.store.ingest_snapshot(first)
+        result = self.store.ingest_snapshot(rerun)
+
+        self.assertEqual(result["origins_inserted"], 0)
+        self.assertEqual(result["predictions_inserted"], 0)
+        stats = self.store.stats()
+        self.assertEqual(stats["origins"], 1)
+        self.assertEqual(stats["predictions"], 6)
+
+        ensemble = next(
+            row
+            for row in self.store.export_rows()
+            if row["model_name"] == ENSEMBLE_MODEL and row["horizon_hours"] == 2
+        )
+        self.assertEqual(ensemble["predicted_price_usd"], 102.0)
+        self.assertEqual(ensemble["generated_at"], first["generated_at"])
+
+    def test_outcomes_only_mature_on_exact_target_timestamp(self) -> None:
+        self.store.ingest_snapshot(make_snapshot(self.origin))
+        target_2h = int((self.origin + timedelta(hours=2)).timestamp())
+        target_4h = int((self.origin + timedelta(hours=4)).timestamp())
+
+        self.assertEqual(self.store.enrich_outcomes({target_2h - 1: 101.0}), 0)
+        self.assertEqual(self.store.stats()["matured_predictions"], 0)
+
+        # The exact +2h candle matures all three +2h logical predictions.
+        self.assertEqual(self.store.enrich_outcomes({target_2h: 101.0}), 3)
+        self.assertEqual(self.store.stats()["matured_predictions"], 3)
+
+        ensemble = next(
+            row
+            for row in self.store.export_rows()
+            if row["model_name"] == ENSEMBLE_MODEL and row["horizon_hours"] == 2
+        )
+        self.assertEqual(ensemble["actual_target_price_usd"], 101.0)
+        self.assertEqual(ensemble["absolute_error_usd"], 1.0)
+        self.assertGreater(ensemble["signed_error_pct"], 0.0)
+        self.assertEqual(ensemble["direction_correct"], 1)
+        self.assertEqual(ensemble["within_q10_q90"], 1)
+
+        # Outcomes are write-once; a later conflicting value cannot rewrite history.
+        self.assertEqual(self.store.enrich_outcomes({target_2h: 999.0}), 0)
+        unchanged = next(
+            row
+            for row in self.store.export_rows()
+            if row["model_name"] == ENSEMBLE_MODEL and row["horizon_hours"] == 2
+        )
+        self.assertEqual(unchanged["actual_target_price_usd"], 101.0)
+
+        self.assertEqual(self.store.enrich_outcomes({target_4h: 104.0}), 3)
+        self.assertEqual(self.store.stats()["pending_predictions"], 0)
+
+    def test_rolling_cache_migration_is_idempotent(self) -> None:
+        snapshots = [
+            make_snapshot(self.origin),
+            make_snapshot(self.origin + timedelta(hours=2), source_price=101.0, ensemble_2h=102.5),
+        ]
+        target = int((self.origin + timedelta(hours=2)).timestamp())
+        first = self.store.ingest_snapshots(snapshots, {target: 101.0})
+        second = self.store.ingest_snapshots(snapshots, {target: 101.0})
+        self.assertEqual(first["origins_inserted"], 2)
+        self.assertEqual(first["predictions_inserted"], 12)
+        self.assertEqual(second["origins_inserted"], 0)
+        self.assertEqual(second["predictions_inserted"], 0)
+        self.assertEqual(self.store.stats()["origins"], 2)
+
+    def test_load_snapshots_reconstructs_adaptive_history_shape(self) -> None:
+        snapshot = make_snapshot(self.origin)
+        self.store.ingest_snapshot(snapshot)
+        loaded = self.store.load_snapshots()
+        self.assertEqual(len(loaded), 1)
+        item = loaded[0]
+        self.assertEqual(item["latest_close_at"], self.origin.isoformat())
+        self.assertEqual(item["regime"], "range")
+        self.assertEqual(item["predictions"]["2h"]["price_usd"], 102.0)
+        self.assertEqual(item["model_predictions"]["timesfm_168h"]["4h"]["price_usd"], 104.0)
+        self.assertAlmostEqual(item["model_weights"]["2h"]["timesfm_168h"], 0.6)
+
+    def test_performance_summary_uses_all_matured_rows(self) -> None:
+        second_origin = self.origin + timedelta(hours=6)
+        self.store.ingest_snapshot(make_snapshot(self.origin))
+        self.store.ingest_snapshot(make_snapshot(second_origin, source_price=105.0, ensemble_2h=106.0))
+        actuals = {
+            int((self.origin + timedelta(hours=2)).timestamp()): 101.0,
+            int((second_origin + timedelta(hours=2)).timestamp()): 107.0,
+        }
+        self.store.enrich_outcomes(actuals)
+        summary = self.store.performance_summary()
+        self.assertEqual(summary["2h"]["samples"], 2)
+        self.assertEqual(summary["2h"]["models"]["persistence"]["samples"], 2)
+        self.assertGreater(summary["2h"]["mae_pct"], 0.0)
+
+    def test_csv_and_jsonl_exports_are_analysis_ready(self) -> None:
+        self.store.ingest_snapshot(make_snapshot(self.origin))
+        csv_path = Path(self.tmp.name) / "history.csv"
+        jsonl_path = Path(self.tmp.name) / "history.jsonl"
+        self.assertEqual(self.store.export(csv_path, "csv"), 6)
+        self.assertEqual(self.store.export(jsonl_path, "jsonl"), 6)
+
+        with csv_path.open(encoding="utf-8") as handle:
+            csv_rows = list(csv.DictReader(handle))
+        self.assertEqual(len(csv_rows), 6)
+        self.assertIn("actual_target_price_usd", csv_rows[0])
+        self.assertIn("market_features_json", csv_rows[0])
+
+        lines = jsonl_path.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(lines), 6)
+        self.assertEqual(json.loads(lines[0])["origin_at"], self.origin.isoformat())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a versioned SQLite history store as the durable source of truth for production forecasts
- persist one immutable logical row per forecast origin/model/horizon and enrich it later with exact matured Kraken outcomes
- make manual reruns idempotent and first-write-wins so they cannot rewrite historical predictions
- migrate the existing rolling Actions cache into the durable store on first use
- make adaptive weighting load snapshots from the durable database while keeping the rolling cache for scheduler state
- publish the canonical SQLite DB, a CSV export, and a one-generation backup as assets on the `forecast-history-v1` GitHub Release
- verify SQLite integrity/foreign keys before upload and refuse to overwrite an existing Release unless it was successfully restored in the same run
- provide `history_store.py` commands for verify/stats/summary/CSV/JSONL export
- add unit coverage for schema versioning, idempotency, outcome maturation, reconstruction, summaries, migration, and exports
- document schema, retention, recovery, query/export, and storage design

## Storage design
The generated dataset is not committed to the source tree. GitHub Actions stores `forecast_history.sqlite.gz` in a dedicated machine-managed Release, with `forecast_history.csv.gz` for analysis and `forecast_history.previous.sqlite.gz` as a bounded recovery copy. The workflow uses the built-in `GITHUB_TOKEN` with `contents: write`; no new secret is required.

## Data integrity
Predictions use `(origin_at, model_name, horizon_hours)` as their logical key. Existing predictions and matured outcomes are never overwritten. Pending outcomes are filled only from an exact matching completed Kraken candle timestamp.

Closes #5