### PR TITLE
Use durable adaptive performance-based ensemble weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,22 @@ The adaptive score uses:
 - recent MAE % as the main signal
 - direction accuracy as a smaller reward
 - signed bias as a penalty
+- Q10-Q90 coverage as a small calibration penalty when a model exposes quantiles
 - performance relative to the persistence baseline
 
-The current market regime is preferred when there are enough matching samples. If regime-specific history is sparse, the system can use all recent regimes. With fewer than 6 matured samples per current model it falls back to the original static regime prior.
+Production weighting consumes the **matured outcomes stored in the durable SQLite history**, so observations remain usable after their Kraken candles have fallen outside the recent OHLC API window. During walk-forward backtests there is no durable outcome shortcut: a previous forecast can only be scored once its target candle is already visible at the current simulated origin.
+
+The current market regime is preferred when there are enough matching samples. If regime-specific history is sparse, the system falls back to recent observations from all regimes. With fewer than 6 matured samples per current model it uses the static regime prior.
+
+The rolling sample limit defaults to **200 relevant matured observations per model/horizon/regime** and applies *after* regime filtering, rather than simply slicing the latest 200 forecast origins. It can be changed without code changes:
+
+```bash
+export BTC_ADAPTIVE_HISTORY_LIMIT=300
+```
 
 Adaptation is deliberately gradual. The learned distribution is blended with the static prior and reaches at most 80% of the final decision after enough observations. Every active model is constrained to a 3% minimum and 55% maximum weight, preventing one short lucky streak from taking over the ensemble.
 
 If the non-persistence models are collectively failing to beat persistence, the weighting logic explicitly boosts the persistence baseline before the final bounded normalization.
-
-Only target prices already present in completed historical candles are used when computing weights. Future outcomes are never consulted, avoiding look-ahead leakage in production and walk-forward tests.
 
 `forecast.json` exposes the result per horizon:
 
@@ -93,9 +100,9 @@ model_weights.16h
 weighting_diagnostics.<horizon>
 ```
 
-The diagnostics include static prior weight, recent sample count, MAE, direction accuracy, signed bias, raw adaptive score, learned weight, final weight, persistence edge, blend factor and whether the persistence fallback was activated.
+The diagnostics include adaptive/static mode, selected history source, configured history limit, per-model sample count, MAE, direction accuracy, signed bias, Q10-Q90 coverage and interval sample count, durable-vs-current-candle outcome counts, raw adaptive score, learned weight, final weight, persistence edge, blend factor and whether the persistence fallback was activated.
 
-Production adaptive weighting now loads its snapshots from the durable SQLite history database. On the first run after this feature is deployed, the existing rolling Actions cache is migrated into SQLite so the observations already collected are not lost.
+This makes the weighting reproducible and observable while preserving strict no-look-ahead behavior. Sparse samples shrink toward the existing prior; sufficient samples can move each horizon and regime to a different learned model mix.
 
 ## Durable production history
 
@@ -286,7 +293,7 @@ Run locally:
 python backtest.py --days 90 --samples 60
 ```
 
-The backtest feeds only prior forecast snapshots into each new forecast, so adaptive weights can learn during the walk-forward run without seeing future targets.
+The backtest feeds only prior forecast snapshots into each new forecast, so adaptive weights can learn during the walk-forward run without seeing future targets. It uses the same adaptive scoring policy and configured history limit as production.
 
 The result is written to `backtest_report.json` with MAE %, mean signed error, direction accuracy, ensemble interval coverage and adaptive ensemble performance by regime.
 
@@ -301,7 +308,7 @@ pip install -r requirements-test.txt
 python -m unittest discover -s . -p 'test_*.py' -v
 ```
 
-The history-store tests cover schema verification, idempotent manual reruns, first-write-wins predictions, exact-target maturation, write-once outcomes, rolling-cache migration, adaptive-history reconstruction and CSV/JSONL export.
+The adaptive tests cover sparse-history fallback, current-regime/all-regime selection, durable outcomes beyond the recent candle window, configurable rolling limits, interval-coverage scoring, persistence fallback and strict weight floors/caps. The history-store tests cover schema verification, idempotent manual reruns, first-write-wins predictions, exact-target maturation, write-once outcomes, rolling-cache migration, adaptive-history reconstruction and CSV/JSONL export.
 
 ## Production output
 

--- a/adaptive_weighting.py
+++ b/adaptive_weighting.py
@@ -1,0 +1,348 @@
+"""Adaptive performance-based ensemble weighting.
+
+This module keeps the weighting policy separate from the forecasting engine so it
+can consume durable matured outcomes without coupling TimesFM inference to the
+SQLite storage implementation. Production attaches persisted outcomes to the
+reconstructed snapshots; walk-forward backtests fall back to candles that are
+known at each simulated forecast origin.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+import numpy as np
+
+from forecast_engine import (
+    ADAPTIVE_DIRECTION_REWARD,
+    ADAPTIVE_FULL_SAMPLES,
+    ADAPTIVE_MAE_LAMBDA,
+    ADAPTIVE_MAX_BLEND,
+    ADAPTIVE_MAX_WEIGHT,
+    ADAPTIVE_MIN_SAMPLES,
+    ADAPTIVE_MIN_WEIGHT,
+    PERSISTENCE_FALLBACK_BOOST,
+    _bounded_normalize,
+    static_model_weights,
+)
+
+DEFAULT_HISTORY_LIMIT = max(ADAPTIVE_MIN_SAMPLES, int(os.getenv("BTC_ADAPTIVE_HISTORY_LIMIT", "200")))
+TARGET_INTERVAL_COVERAGE = 0.80
+COVERAGE_PENALTY = 0.35
+MIN_COVERAGE_SAMPLES = 3
+
+
+def _direction(value: float, epsilon: float = 1e-12) -> int:
+    return 1 if value > epsilon else -1 if value < -epsilon else 0
+
+
+def attach_persisted_outcomes(
+    snapshots: list[dict[str, Any]],
+    rows: Iterable[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Attach matured SQLite outcome rows to reconstructed forecast snapshots.
+
+    The returned list reuses the snapshot dictionaries and adds a private
+    ``_outcomes`` mapping. Persisted outcomes are authoritative and allow
+    adaptive weighting to use history older than Kraken's recent OHLC window.
+    """
+    by_origin = {
+        str(snapshot.get("latest_close_at")): snapshot
+        for snapshot in snapshots
+        if snapshot.get("latest_close_at")
+    }
+    for row in rows:
+        actual = row.get("actual_target_price_usd")
+        if actual is None:
+            continue
+        snapshot = by_origin.get(str(row.get("origin_at")))
+        if snapshot is None:
+            continue
+        model_name = str(row.get("model_name"))
+        if model_name == "ensemble":
+            continue
+        try:
+            hour = int(row["horizon_hours"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        horizon = f"{hour}h"
+        snapshot.setdefault("_outcomes", {}).setdefault(horizon, {})[model_name] = {
+            "actual_target_price_usd": float(actual),
+            "absolute_error_pct": row.get("absolute_error_pct"),
+            "signed_error_pct": row.get("signed_error_pct"),
+            "direction_correct": row.get("direction_correct"),
+            "within_q10_q90": row.get("within_q10_q90"),
+            "matured_at": row.get("matured_at"),
+        }
+    return snapshots
+
+
+def _persisted_actual(snapshot: dict[str, Any], horizon: str, model_name: str) -> float | None:
+    try:
+        value = snapshot["_outcomes"][horizon][model_name]["actual_target_price_usd"]
+    except (KeyError, TypeError):
+        return None
+    try:
+        actual = float(value)
+    except (TypeError, ValueError):
+        return None
+    return actual if actual > 0 else None
+
+
+def _score_history_for_model(
+    history: list[dict[str, Any]],
+    actual_by_timestamp: dict[int, float],
+    model_name: str,
+    hour: int,
+    regime: str | None,
+    history_limit: int,
+) -> list[dict[str, float | bool | None | str]]:
+    horizon = f"{hour}h"
+    scores: list[dict[str, float | bool | None | str]] = []
+
+    # Newest samples win. The limit applies after horizon/regime filtering, so a
+    # rare regime can use up to the configured number of relevant observations.
+    for snapshot in reversed(history):
+        if len(scores) >= history_limit:
+            break
+        if regime is not None and snapshot.get("regime") != regime:
+            continue
+        try:
+            origin = datetime.fromisoformat(str(snapshot["latest_close_at"]).replace("Z", "+00:00"))
+            if origin.tzinfo is None:
+                origin = origin.replace(tzinfo=timezone.utc)
+            origin = origin.astimezone(timezone.utc)
+            previous_close = float(snapshot["latest_close_usd"])
+            item = snapshot["model_predictions"][model_name][horizon]
+            predicted = float(item["price_usd"])
+        except (KeyError, TypeError, ValueError):
+            continue
+
+        actual = _persisted_actual(snapshot, horizon, model_name)
+        outcome_source = "durable"
+        if actual is None:
+            target = int(origin.timestamp()) + hour * 3600
+            candle_actual = actual_by_timestamp.get(target)
+            if candle_actual is None or float(candle_actual) <= 0:
+                continue
+            actual = float(candle_actual)
+            outcome_source = "candle"
+
+        error = predicted - actual
+        q10 = item.get("q10_usd") if isinstance(item, dict) else None
+        q90 = item.get("q90_usd") if isinstance(item, dict) else None
+        within: bool | None = None
+        if q10 is not None and q90 is not None:
+            try:
+                within = float(q10) <= actual <= float(q90)
+            except (TypeError, ValueError):
+                within = None
+
+        scores.append(
+            {
+                "absolute_error_pct": abs(error) / actual * 100.0,
+                "signed_error_pct": error / actual * 100.0,
+                "direction_correct": _direction(predicted - previous_close)
+                == _direction(actual - previous_close),
+                "within_q10_q90": within,
+                "outcome_source": outcome_source,
+            }
+        )
+
+    # Metric aggregation is order-independent; restore chronological ordering for
+    # deterministic diagnostics and easier debugging.
+    scores.reverse()
+    return scores
+
+
+def _performance_metrics(scores: list[dict[str, Any]]) -> dict[str, float | int | None]:
+    covered = [bool(score["within_q10_q90"]) for score in scores if score.get("within_q10_q90") is not None]
+    durable_samples = sum(score.get("outcome_source") == "durable" for score in scores)
+    return {
+        "samples": len(scores),
+        "mae_pct": float(np.mean([float(s["absolute_error_pct"]) for s in scores])),
+        "mean_signed_error_pct": float(np.mean([float(s["signed_error_pct"]) for s in scores])),
+        "direction_accuracy": float(np.mean([bool(s["direction_correct"]) for s in scores])),
+        "q10_q90_coverage": float(np.mean(covered)) if covered else None,
+        "interval_samples": len(covered),
+        "durable_outcome_samples": durable_samples,
+        "candle_outcome_samples": len(scores) - durable_samples,
+    }
+
+
+def adaptive_model_weights(
+    model_names: list[str],
+    regime: str,
+    hour: int,
+    history: list[dict[str, Any]],
+    actual_by_timestamp: dict[int, float],
+    enabled: bool = True,
+    history_limit: int | None = None,
+) -> tuple[dict[str, float], dict[str, Any]]:
+    """Blend static priors with recent out-of-sample performance.
+
+    Weighting is independent per horizon. Current-regime samples are preferred;
+    all regimes are used when the current regime is sparse. Learned weights are
+    shrunk toward the hand-tuned prior, bounded, and biased back toward
+    persistence when the complex models fail to beat it.
+    """
+    limit = max(ADAPTIVE_MIN_SAMPLES, int(history_limit or DEFAULT_HISTORY_LIMIT))
+    prior = static_model_weights(model_names, regime)
+
+    regime_scores = {
+        name: _score_history_for_model(history, actual_by_timestamp, name, hour, regime, limit)
+        for name in model_names
+    }
+    all_scores = {
+        name: _score_history_for_model(history, actual_by_timestamp, name, hour, None, limit)
+        for name in model_names
+    }
+
+    min_regime_samples = min((len(scores) for scores in regime_scores.values()), default=0)
+    min_all_samples = min((len(scores) for scores in all_scores.values()), default=0)
+
+    if not enabled:
+        source = "disabled"
+        selected = all_scores
+    elif min_regime_samples >= ADAPTIVE_MIN_SAMPLES:
+        source = "regime"
+        selected = regime_scores
+    elif min_all_samples >= ADAPTIVE_MIN_SAMPLES:
+        source = "all_regimes"
+        selected = all_scores
+    else:
+        source = "insufficient_history"
+        selected = all_scores
+
+    metrics = {
+        name: _performance_metrics(scores)
+        if scores
+        else {
+            "samples": 0,
+            "mae_pct": None,
+            "mean_signed_error_pct": None,
+            "direction_accuracy": None,
+            "q10_q90_coverage": None,
+            "interval_samples": 0,
+            "durable_outcome_samples": 0,
+            "candle_outcome_samples": 0,
+        }
+        for name, scores in selected.items()
+    }
+
+    if not enabled or source == "insufficient_history":
+        diagnostics = {
+            "mode": "static_prior",
+            "source": source,
+            "horizon": f"{hour}h",
+            "regime": regime,
+            "history_limit": limit,
+            "blend_factor": 0.0,
+            "sample_count": min_all_samples if source != "regime" else min_regime_samples,
+            "persistence_mae_pct": metrics.get("persistence", {}).get("mae_pct"),
+            "models": {
+                name: {
+                    **metric,
+                    "prior_weight": round(prior[name], 6),
+                    "raw_score": None,
+                    "adaptive_weight": None,
+                    "final_weight": round(prior[name], 6),
+                    "edge_vs_persistence_mae_pct": None,
+                }
+                for name, metric in metrics.items()
+            },
+        }
+        return prior, diagnostics
+
+    persistence_mae = (
+        float(metrics["persistence"]["mae_pct"])
+        if "persistence" in metrics and metrics["persistence"]["mae_pct"] is not None
+        else None
+    )
+    raw_scores: dict[str, float] = {}
+    for name, metric in metrics.items():
+        mae = float(metric["mae_pct"])
+        direction_accuracy = float(metric["direction_accuracy"])
+        bias = abs(float(metric["mean_signed_error_pct"]))
+
+        score = math.exp(-ADAPTIVE_MAE_LAMBDA * mae)
+        score *= 1.0 + ADAPTIVE_DIRECTION_REWARD * (direction_accuracy - 0.5) * 2.0
+        score *= math.exp(-0.35 * bias)
+
+        coverage = metric.get("q10_q90_coverage")
+        if coverage is not None and int(metric.get("interval_samples") or 0) >= MIN_COVERAGE_SAMPLES:
+            score *= math.exp(-COVERAGE_PENALTY * abs(float(coverage) - TARGET_INTERVAL_COVERAGE))
+
+        if persistence_mae is not None and name != "persistence":
+            edge = persistence_mae - mae
+            if edge < 0:
+                score *= math.exp(1.5 * edge)
+
+        raw_scores[name] = max(score, 1e-9)
+
+    raw_total = sum(raw_scores.values())
+    adaptive = {name: score / raw_total for name, score in raw_scores.items()}
+
+    sample_count = min(int(metric["samples"]) for metric in metrics.values())
+    progress = min(
+        1.0,
+        max(
+            0.0,
+            (sample_count - ADAPTIVE_MIN_SAMPLES)
+            / max(1, ADAPTIVE_FULL_SAMPLES - ADAPTIVE_MIN_SAMPLES),
+        ),
+    )
+    blend = 0.25 + (ADAPTIVE_MAX_BLEND - 0.25) * progress
+    blended = {
+        name: (1.0 - blend) * prior[name] + blend * adaptive[name]
+        for name in model_names
+    }
+
+    complex_maes = [
+        float(metrics[name]["mae_pct"])
+        for name in model_names
+        if name != "persistence" and metrics[name]["mae_pct"] is not None
+    ]
+    persistence_fallback = False
+    if (
+        persistence_mae is not None
+        and complex_maes
+        and float(np.mean(complex_maes)) >= persistence_mae
+        and "persistence" in blended
+    ):
+        blended["persistence"] += PERSISTENCE_FALLBACK_BOOST
+        persistence_fallback = True
+
+    final = _bounded_normalize(blended, ADAPTIVE_MIN_WEIGHT, ADAPTIVE_MAX_WEIGHT)
+    diagnostics: dict[str, Any] = {
+        "mode": "adaptive",
+        "source": source,
+        "horizon": f"{hour}h",
+        "regime": regime,
+        "history_limit": limit,
+        "blend_factor": round(blend, 4),
+        "sample_count": sample_count,
+        "persistence_fallback": persistence_fallback,
+        "persistence_mae_pct": round(persistence_mae, 6) if persistence_mae is not None else None,
+        "models": {},
+    }
+    for name, metric in metrics.items():
+        mae = float(metric["mae_pct"])
+        diagnostics["models"][name] = {
+            **{
+                key: round(value, 6) if isinstance(value, float) else value
+                for key, value in metric.items()
+            },
+            "prior_weight": round(prior[name], 6),
+            "raw_score": round(raw_scores[name], 8),
+            "adaptive_weight": round(adaptive[name], 6),
+            "final_weight": round(final[name], 6),
+            "edge_vs_persistence_mae_pct": (
+                round(persistence_mae - mae, 6) if persistence_mae is not None else None
+            ),
+        }
+
+    return final, diagnostics

--- a/backtest.py
+++ b/backtest.py
@@ -19,6 +19,8 @@ from typing import Any
 import numpy as np
 import requests
 
+import forecast_engine
+from adaptive_weighting import DEFAULT_HISTORY_LIMIT, adaptive_model_weights
 from forecast_engine import (
     MarketData,
     TARGET_HOURS,
@@ -30,6 +32,11 @@ from forecast_engine import (
 
 BINANCE_KLINES = "https://api.binance.com/api/v3/klines"
 REPORT_PATH = Path("backtest_report.json")
+
+# Use the same issue #6 adaptive policy as production. During walk-forward tests
+# there is no durable DB; only target candles already visible at each simulated
+# origin can mature prior forecasts, which preserves no-look-ahead behavior.
+forecast_engine.adaptive_model_weights = adaptive_model_weights
 
 
 def fetch_binance_history(days: int) -> MarketData:
@@ -206,7 +213,7 @@ def main() -> None:
             }
         )
         history.append(history_snapshot(forecast))
-        history = history[-72:]
+        history = history[-DEFAULT_HISTORY_LIMIT:]
         modes = sorted({str(p["weighting_mode"]) for p in forecast["predictions"].values()})
         print(
             f"Backtest {number}/{len(indices)}: {samples[-1]['origin_at']} "
@@ -216,6 +223,7 @@ def main() -> None:
     report = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "data_source": "Binance BTCUSDT 1h (historical proxy for BTC/USD)",
+        "adaptive_history_limit": DEFAULT_HISTORY_LIMIT,
         "days_requested": args.days,
         "samples": len(samples),
         "summary": summarize(samples),

--- a/btc_forecast.py
+++ b/btc_forecast.py
@@ -10,6 +10,8 @@ from typing import Any
 
 import numpy as np
 
+import forecast_engine
+from adaptive_weighting import adaptive_model_weights, attach_persisted_outcomes
 from forecast_engine import TARGET_HOURS, build_forecast, fetch_kraken_hourly, load_timesfm
 from history_store import DEFAULT_DB_PATH, ForecastHistoryStore
 
@@ -19,6 +21,11 @@ TWEET_PATH = Path("tweet.txt")
 STATE_PATH = Path(".state/previous_forecast.json")
 HISTORY_DB_PATH = DEFAULT_DB_PATH
 HISTORY_LIMIT = 72
+
+# build_forecast resolves this function from forecast_engine's module globals.
+# Install the issue #6 policy once so production uses the durable-history-aware
+# weighting implementation while keeping the engine API stable.
+forecast_engine.adaptive_model_weights = adaptive_model_weights
 
 
 def load_forecast_history() -> list[dict[str, Any]]:
@@ -280,7 +287,10 @@ def main() -> None:
     store = ForecastHistoryStore(HISTORY_DB_PATH)
     migration = store.ingest_snapshots(rolling_history, actuals)
     durable_history = store.load_snapshots()
-    history = durable_history or rolling_history
+    if durable_history:
+        history = attach_persisted_outcomes(durable_history, store.export_rows())
+    else:
+        history = rolling_history
 
     reliability = score_forecast_history(history, data.closes, data.timestamps)
     summary = store.performance_summary()

--- a/test_adaptive_weights.py
+++ b/test_adaptive_weights.py
@@ -10,11 +10,14 @@ from unit_test_stubs import install_timesfm_stub
 
 install_timesfm_stub()
 
+from adaptive_weighting import (  # noqa: E402
+    attach_persisted_outcomes,
+    adaptive_model_weights,
+)
 from forecast_engine import (  # noqa: E402
     ADAPTIVE_MAX_WEIGHT,
     ADAPTIVE_MIN_WEIGHT,
     _bounded_normalize,
-    adaptive_model_weights,
     static_model_weights,
 )
 
@@ -29,6 +32,7 @@ def snapshot(
     *,
     regime: str = "range",
     complex_offset: float | None = None,
+    with_intervals: bool = False,
 ) -> tuple[dict, int, float]:
     if complex_offset is None:
         predictions = {
@@ -47,15 +51,29 @@ def snapshot(
             "ar1": actual + complex_offset,
         }
 
+    model_predictions = {}
+    for name, price in predictions.items():
+        item = {"price_usd": price}
+        if with_intervals and name.startswith("timesfm_"):
+            item.update({"q10_usd": actual - 1.0, "q90_usd": actual + 1.0})
+        model_predictions[name] = {"2h": item}
+
     item = {
         "latest_close_at": origin.isoformat(),
         "latest_close_usd": current,
         "regime": regime,
-        "model_predictions": {
-            name: {"2h": {"price_usd": price}} for name, price in predictions.items()
-        },
+        "model_predictions": model_predictions,
     }
     return item, int((origin + timedelta(hours=2)).timestamp()), actual
+
+
+def add_durable_outcome(item: dict, actual: float) -> None:
+    item["_outcomes"] = {
+        "2h": {
+            name: {"actual_target_price_usd": actual, "matured_at": "2026-01-02T00:00:00+00:00"}
+            for name in MODELS
+        }
+    }
 
 
 class AdaptiveWeightTests(unittest.TestCase):
@@ -131,6 +149,110 @@ class AdaptiveWeightTests(unittest.TestCase):
         self.assertTrue(diagnostics["persistence_fallback"])
         self.assertGreater(weights["persistence"], ADAPTIVE_MIN_WEIGHT)
         self.assertEqual(diagnostics["persistence_mae_pct"], 0.0)
+
+    def test_durable_outcomes_work_without_recent_candle_map(self) -> None:
+        start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        history = []
+        for i in range(8):
+            current = 100.0 + i
+            actual = current + 1.0
+            item, _, _ = snapshot(start + timedelta(hours=2 * i), current, actual)
+            add_durable_outcome(item, actual)
+            history.append(item)
+
+        _, diagnostics = adaptive_model_weights(MODELS, "range", 2, history, {})
+        self.assertEqual(diagnostics["mode"], "adaptive")
+        self.assertEqual(diagnostics["sample_count"], 8)
+        for model in MODELS:
+            self.assertEqual(
+                diagnostics["models"][model]["durable_outcome_samples"], 8
+            )
+            self.assertEqual(
+                diagnostics["models"][model]["candle_outcome_samples"], 0
+            )
+
+    def test_history_limit_applies_after_regime_filtering(self) -> None:
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        history = []
+        actuals = {}
+        for i in range(20):
+            regime = "range" if i % 2 == 0 else "trending"
+            current = 100.0 + i
+            actual = current + 1.0
+            item, target, target_price = snapshot(
+                start + timedelta(hours=2 * i), current, actual, regime=regime
+            )
+            history.append(item)
+            actuals[target] = target_price
+
+        _, diagnostics = adaptive_model_weights(
+            MODELS, "range", 2, history, actuals, history_limit=7
+        )
+        self.assertEqual(diagnostics["source"], "regime")
+        self.assertEqual(diagnostics["sample_count"], 7)
+        self.assertEqual(diagnostics["history_limit"], 7)
+
+    def test_interval_coverage_is_measured_and_affects_score(self) -> None:
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        history = []
+        actuals = {}
+        for i in range(10):
+            current = 100.0 + i
+            actual = current + 1.0
+            item, target, target_price = snapshot(
+                start + timedelta(hours=2 * i), current, actual, with_intervals=True
+            )
+            # Give both TimesFM contexts identical point forecasts so coverage is
+            # the only difference between their raw performance scores.
+            item["model_predictions"]["timesfm_168h"]["2h"]["price_usd"] = actual + 0.1
+            item["model_predictions"]["timesfm_336h"]["2h"]["price_usd"] = actual + 0.1
+            # 168h gets 8/10 ~= target 80%; 336h misses all intervals.
+            if i >= 8:
+                item["model_predictions"]["timesfm_168h"]["2h"].update(
+                    {"q10_usd": actual + 2.0, "q90_usd": actual + 3.0}
+                )
+            item["model_predictions"]["timesfm_336h"]["2h"].update(
+                {"q10_usd": actual + 2.0, "q90_usd": actual + 3.0}
+            )
+            history.append(item)
+            actuals[target] = target_price
+
+        _, diagnostics = adaptive_model_weights(MODELS, "range", 2, history, actuals)
+        m168 = diagnostics["models"]["timesfm_168h"]
+        m336 = diagnostics["models"]["timesfm_336h"]
+        self.assertEqual(m168["interval_samples"], 10)
+        self.assertAlmostEqual(m168["q10_q90_coverage"], 0.8)
+        self.assertEqual(m336["q10_q90_coverage"], 0.0)
+        self.assertGreater(m168["raw_score"], m336["raw_score"])
+
+    def test_attach_persisted_outcomes_maps_rows_by_origin_model_and_horizon(self) -> None:
+        origin = datetime(2026, 1, 1, tzinfo=timezone.utc).isoformat()
+        snapshots = [{"latest_close_at": origin}]
+        rows = [
+            {
+                "origin_at": origin,
+                "model_name": "timesfm_168h",
+                "horizon_hours": 2,
+                "actual_target_price_usd": 101.0,
+                "absolute_error_pct": 0.2,
+                "signed_error_pct": -0.2,
+                "direction_correct": 1,
+                "within_q10_q90": 1,
+                "matured_at": "2026-01-01T03:00:00+00:00",
+            },
+            {
+                "origin_at": origin,
+                "model_name": "ensemble",
+                "horizon_hours": 2,
+                "actual_target_price_usd": 101.0,
+            },
+        ]
+        result = attach_persisted_outcomes(snapshots, rows)
+        self.assertEqual(
+            result[0]["_outcomes"]["2h"]["timesfm_168h"]["actual_target_price_usd"],
+            101.0,
+        )
+        self.assertNotIn("ensemble", result[0]["_outcomes"]["2h"])
 
     def test_weights_respect_bounds_and_sum_to_one(self) -> None:
         weights = _bounded_normalize({"a": 100.0, "b": 1.0, "c": 1.0, "d": 1.0})


### PR DESCRIPTION
## Summary
- implement issue #6 as a dedicated adaptive weighting policy shared by production and walk-forward backtests
- score each model independently by horizon and regime using recent out-of-sample MAE, direction accuracy, signed bias, interval coverage and edge vs persistence
- consume matured outcomes from the durable SQLite history so weighting can learn from observations older than Kraken's recent OHLC window
- use a configurable relevant-sample rolling limit (`BTC_ADAPTIVE_HISTORY_LIMIT`, default 200) applied after regime filtering
- keep sparse-history shrinkage toward static priors, strict 3%-55% model bounds and the persistence fallback
- expose interval coverage, durable/current-candle sample counts, history limit, raw scores and final weights in weighting diagnostics
- make the walk-forward backtest use the exact same adaptive policy while preserving no-look-ahead behavior
- add unit coverage for durable outcomes, coverage scoring, rolling limits, fallback behavior and bounds
- update README algorithm and safeguards

## No-look-ahead
Production only consumes outcomes already matured in the durable store. The backtest does not attach durable outcomes and can only score a prior prediction after its target candle is present in the simulated context.

Closes #6