### PR TITLE
Add strict market data validation

### DIFF
--- a/.github/workflows/backtest.yml
+++ b/.github/workflows/backtest.yml
@@ -45,10 +45,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run walk-forward backtest
-        run: python backtest.py --days "${{ inputs.days }}" --samples "${{ inputs.samples }}"
+      - name: Validate historical data and run walk-forward backtest
+        run: python validated_entrypoints.py backtest --days "${{ inputs.days }}" --samples "${{ inputs.samples }}"
+
+      - name: Add validation to summary
+        if: always() && hashFiles('market_data_validation.json') != ''
+        run: |
+          echo '## Market data validation' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat market_data_validation.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Add report to summary
+        if: hashFiles('backtest_report.json') != ''
         run: |
           echo '## BTC forecast backtest' >> "$GITHUB_STEP_SUMMARY"
           echo '```json' >> "$GITHUB_STEP_SUMMARY"
@@ -56,8 +65,12 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: btc-backtest-${{ github.run_id }}
-          path: backtest_report.json
+          path: |
+            backtest_report.json
+            market_data_validation.json
+          if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/forecast.yml
+++ b/.github/workflows/forecast.yml
@@ -93,9 +93,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Forecast BTC and persist matured predictions
+      - name: Validate market data and forecast BTC
         if: steps.due.outputs.run_forecast == 'true'
-        run: python btc_forecast.py
+        run: python validated_entrypoints.py forecast
+
+      - name: Add market data validation to job summary
+        if: always() && steps.due.outputs.run_forecast == 'true' && hashFiles('market_data_validation.json') != ''
+        run: |
+          echo '## Market data validation' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat market_data_validation.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Format visual X post
         if: steps.due.outputs.run_forecast == 'true'
@@ -191,5 +199,6 @@ jobs:
             forecast.json
             tweet.txt
             x_post_status.json
+            market_data_validation.json
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/optimize.yml
+++ b/.github/workflows/optimize.yml
@@ -52,11 +52,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run bounded walk-forward optimization
+      - name: Validate historical data and run bounded optimization
         run: |
-          python optimizer.py \
+          python validated_entrypoints.py optimizer \
             --days "${{ inputs.days || '120' }}" \
             --samples "${{ inputs.samples || '48' }}"
+
+      - name: Add market data validation summary
+        if: always() && hashFiles('market_data_validation.json') != ''
+        run: |
+          echo '## Market data validation' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat market_data_validation.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Add optimizer summary
         if: always() && hashFiles('optimizer_summary.md') != ''
@@ -70,5 +78,6 @@ jobs:
           path: |
             optimizer_report.json
             optimizer_summary.md
+            market_data_validation.json
           if-no-files-found: warn
           retention-days: 90

--- a/market_data_validation.py
+++ b/market_data_validation.py
@@ -138,14 +138,41 @@ def _add_error(
     count: int = 1,
     samples: list[Any] | None = None,
 ) -> None:
-    item: dict[str, Any] = {
-        "code": code,
-        "message": message,
-        "count": int(count),
-    }
+    item: dict[str, Any] = {"code": code, "message": message, "count": int(count)}
     if samples:
         item["samples"] = samples
     errors.append(item)
+
+
+def trim_incomplete_trailing_candles(
+    data: MarketDataLike,
+    *,
+    now: datetime | None = None,
+) -> int:
+    """Drop trailing candles whose close timestamp is still in the future.
+
+    Binance historical endpoints can include the currently forming kline. The
+    rest of the project stores candle close timestamps, so a timestamp newer
+    than ``now`` is incomplete and must not enter a backtest/optimizer.
+    """
+    checked = now or datetime.now(timezone.utc)
+    if checked.tzinfo is None:
+        checked = checked.replace(tzinfo=timezone.utc)
+    cutoff = int(checked.astimezone(timezone.utc).timestamp())
+
+    timestamps = list(data.timestamps)
+    keep = len(timestamps)
+    while keep and int(timestamps[keep - 1]) > cutoff:
+        keep -= 1
+    removed = len(timestamps) - keep
+    if not removed:
+        return 0
+
+    data.timestamps = timestamps[:keep]
+    for attribute in ("opens", "highs", "lows", "closes", "volumes"):
+        values = getattr(data, attribute)
+        setattr(data, attribute, values[:keep])
+    return removed
 
 
 def validate_market_data(
@@ -156,12 +183,7 @@ def validate_market_data(
     config: ValidationConfig | None = None,
     check_staleness: bool = True,
 ) -> ValidationReport:
-    """Validate OHLCV structure, cadence, freshness, and hard anomalies.
-
-    Any error makes the report fail and raises ``MarketDataValidationError``.
-    Thresholds are intentionally conservative: they are meant to catch corrupt
-    or clearly implausible inputs, not classify ordinary market volatility.
-    """
+    """Validate OHLCV structure, cadence, freshness, and hard anomalies."""
     cfg = config or ValidationConfig.from_env()
     checked = now or datetime.now(timezone.utc)
     if checked.tzinfo is None:
@@ -180,50 +202,27 @@ def validate_market_data(
         "volume": np.asarray(data.volumes, dtype=np.float64),
     }
 
-    lengths = {
-        "timestamps": len(timestamps),
-        **{name: len(values) for name, values in arrays.items()},
-    }
+    lengths = {"timestamps": len(timestamps), **{name: len(values) for name, values in arrays.items()}}
     unique_lengths = set(lengths.values())
     if len(unique_lengths) != 1:
-        _add_error(
-            errors,
-            "length_mismatch",
-            f"OHLCV arrays have inconsistent lengths: {lengths}",
-        )
+        _add_error(errors, "length_mismatch", f"OHLCV arrays have inconsistent lengths: {lengths}")
 
     count = min(lengths.values()) if lengths else 0
     first_timestamp = int(timestamps[0]) if len(timestamps) else None
     latest_timestamp = int(timestamps[-1]) if len(timestamps) else None
 
     if count < cfg.min_candles:
-        _add_error(
-            errors,
-            "insufficient_candles",
-            f"Need at least {cfg.min_candles} candles, got {count}",
-        )
+        _add_error(errors, "insufficient_candles", f"Need at least {cfg.min_candles} candles, got {count}")
 
     if len(timestamps):
         nonpositive_ts = np.where(timestamps <= 0)[0]
         if len(nonpositive_ts):
-            _add_error(
-                errors,
-                "invalid_timestamp",
-                "Timestamps must be positive Unix seconds",
-                count=len(nonpositive_ts),
-                samples=_sample_indices(nonpositive_ts),
-            )
+            _add_error(errors, "invalid_timestamp", "Timestamps must be positive Unix seconds", count=len(nonpositive_ts), samples=_sample_indices(nonpositive_ts))
 
     for name, values in arrays.items():
         bad = np.where(~np.isfinite(values))[0]
         if len(bad):
-            _add_error(
-                errors,
-                f"non_finite_{name}",
-                f"{name} contains NaN or infinity",
-                count=len(bad),
-                samples=_sample_indices(bad),
-            )
+            _add_error(errors, f"non_finite_{name}", f"{name} contains NaN or infinity", count=len(bad), samples=_sample_indices(bad))
 
     if len(unique_lengths) == 1 and count:
         opens = arrays["open"]
@@ -232,38 +231,16 @@ def validate_market_data(
         closes = arrays["close"]
         volumes = arrays["volume"]
 
-        for name, values in (
-            ("open", opens),
-            ("high", highs),
-            ("low", lows),
-            ("close", closes),
-        ):
+        for name, values in (("open", opens), ("high", highs), ("low", lows), ("close", closes)):
             bad = np.where(values <= 0)[0]
             if len(bad):
-                _add_error(
-                    errors,
-                    f"non_positive_{name}",
-                    f"{name} prices must be positive",
-                    count=len(bad),
-                    samples=_sample_indices(bad),
-                )
+                _add_error(errors, f"non_positive_{name}", f"{name} prices must be positive", count=len(bad), samples=_sample_indices(bad))
 
         bad_volume = np.where(volumes <= 0)[0]
         if len(bad_volume):
-            _add_error(
-                errors,
-                "non_positive_volume",
-                "Volume must be positive",
-                count=len(bad_volume),
-                samples=_sample_indices(bad_volume),
-            )
+            _add_error(errors, "non_positive_volume", "Volume must be positive", count=len(bad_volume), samples=_sample_indices(bad_volume))
 
-        if (
-            np.all(np.isfinite(opens))
-            and np.all(np.isfinite(highs))
-            and np.all(np.isfinite(lows))
-            and np.all(np.isfinite(closes))
-        ):
+        if all(np.all(np.isfinite(values)) for values in (opens, highs, lows, closes)):
             invalid_ohlc = np.where(
                 (highs < opens)
                 | (highs < closes)
@@ -273,42 +250,21 @@ def validate_market_data(
                 | (lows > highs)
             )[0]
             if len(invalid_ohlc):
-                _add_error(
-                    errors,
-                    "invalid_ohlc",
-                    "OHLC relationship is impossible (high/low do not bound open/close)",
-                    count=len(invalid_ohlc),
-                    samples=_sample_indices(invalid_ohlc),
-                )
+                _add_error(errors, "invalid_ohlc", "OHLC relationship is impossible (high/low do not bound open/close)", count=len(invalid_ohlc), samples=_sample_indices(invalid_ohlc))
 
             if np.all(closes > 0) and len(closes) > 1:
                 hourly_returns = np.abs(closes[1:] / closes[:-1] - 1.0) * 100.0
-                max_return = float(np.max(hourly_returns))
-                metrics["max_abs_hourly_return_pct"] = round(max_return, 6)
+                metrics["max_abs_hourly_return_pct"] = round(float(np.max(hourly_returns)), 6)
                 extreme = np.where(hourly_returns > cfg.max_hourly_return_pct)[0] + 1
                 if len(extreme):
-                    _add_error(
-                        errors,
-                        "extreme_hourly_return",
-                        "Absolute close-to-close return exceeds "
-                        f"{cfg.max_hourly_return_pct:.2f}%",
-                        count=len(extreme),
-                        samples=_sample_indices(extreme),
-                    )
+                    _add_error(errors, "extreme_hourly_return", f"Absolute close-to-close return exceeds {cfg.max_hourly_return_pct:.2f}%", count=len(extreme), samples=_sample_indices(extreme))
 
             if np.all(lows > 0):
                 candle_ranges = (highs / lows - 1.0) * 100.0
-                max_range = float(np.max(candle_ranges))
-                metrics["max_candle_range_pct"] = round(max_range, 6)
+                metrics["max_candle_range_pct"] = round(float(np.max(candle_ranges)), 6)
                 extreme = np.where(candle_ranges > cfg.max_candle_range_pct)[0]
                 if len(extreme):
-                    _add_error(
-                        errors,
-                        "extreme_candle_range",
-                        f"High-low candle range exceeds {cfg.max_candle_range_pct:.2f}%",
-                        count=len(extreme),
-                        samples=_sample_indices(extreme),
-                    )
+                    _add_error(errors, "extreme_candle_range", f"High-low candle range exceeds {cfg.max_candle_range_pct:.2f}%", count=len(extreme), samples=_sample_indices(extreme))
 
         if np.all(np.isfinite(volumes)) and np.all(volumes > 0):
             max_ratio = 1.0
@@ -324,39 +280,18 @@ def validate_market_data(
                     volume_outliers.append(index)
             metrics["max_volume_median_multiplier"] = round(max_ratio, 6)
             if volume_outliers:
-                _add_error(
-                    errors,
-                    "extreme_volume",
-                    "Volume exceeds rolling-median anomaly threshold "
-                    f"({cfg.max_volume_median_multiplier:.2f}x)",
-                    count=len(volume_outliers),
-                    samples=volume_outliers[:5],
-                )
+                _add_error(errors, "extreme_volume", f"Volume exceeds rolling-median anomaly threshold ({cfg.max_volume_median_multiplier:.2f}x)", count=len(volume_outliers), samples=volume_outliers[:5])
 
     if len(timestamps) > 1:
         diffs = np.diff(timestamps)
         duplicate = np.where(diffs == 0)[0] + 1
         out_of_order = np.where(diffs < 0)[0] + 1
-        irregular = np.where(
-            (diffs > 0) & (diffs != cfg.interval_seconds)
-        )[0] + 1
+        irregular = np.where((diffs > 0) & (diffs != cfg.interval_seconds))[0] + 1
 
         if len(duplicate):
-            _add_error(
-                errors,
-                "duplicate_timestamp",
-                "Duplicate candle timestamps detected",
-                count=len(duplicate),
-                samples=_sample_indices(duplicate),
-            )
+            _add_error(errors, "duplicate_timestamp", "Duplicate candle timestamps detected", count=len(duplicate), samples=_sample_indices(duplicate))
         if len(out_of_order):
-            _add_error(
-                errors,
-                "out_of_order_timestamp",
-                "Candle timestamps are not strictly increasing",
-                count=len(out_of_order),
-                samples=_sample_indices(out_of_order),
-            )
+            _add_error(errors, "out_of_order_timestamp", "Candle timestamps are not strictly increasing", count=len(out_of_order), samples=_sample_indices(out_of_order))
         if len(irregular):
             gaps = [
                 {
@@ -367,32 +302,16 @@ def validate_market_data(
                 }
                 for index in irregular[:5]
             ]
-            _add_error(
-                errors,
-                "missing_or_irregular_candle",
-                f"Expected exactly {cfg.interval_seconds} seconds between candles",
-                count=len(irregular),
-                samples=gaps,
-            )
+            _add_error(errors, "missing_or_irregular_candle", f"Expected exactly {cfg.interval_seconds} seconds between candles", count=len(irregular), samples=gaps)
 
     if latest_timestamp is not None:
         checked_epoch = checked.timestamp()
         age_seconds = checked_epoch - latest_timestamp
         metrics["latest_age_seconds"] = round(float(age_seconds), 3)
         if latest_timestamp > checked_epoch + cfg.future_tolerance_seconds:
-            _add_error(
-                errors,
-                "future_timestamp",
-                "Latest candle timestamp is unexpectedly in the future",
-            )
+            _add_error(errors, "future_timestamp", "Latest candle timestamp is unexpectedly in the future")
         if check_staleness and age_seconds > cfg.max_staleness_minutes * 60.0:
-            _add_error(
-                errors,
-                "stale_data",
-                "Latest completed candle is stale: "
-                f"{age_seconds / 60.0:.1f} minutes old "
-                f"(limit {cfg.max_staleness_minutes:.1f})",
-            )
+            _add_error(errors, "stale_data", "Latest completed candle is stale: " f"{age_seconds / 60.0:.1f} minutes old " f"(limit {cfg.max_staleness_minutes:.1f})")
 
     report = ValidationReport(
         source=source,
@@ -410,10 +329,7 @@ def validate_market_data(
     return report
 
 
-def persist_validation_report(
-    report: ValidationReport,
-    path: Path = VALIDATION_REPORT_PATH,
-) -> None:
+def persist_validation_report(report: ValidationReport, path: Path = VALIDATION_REPORT_PATH) -> None:
     path.write_text(json.dumps(report.to_dict(), indent=2) + "\n", encoding="utf-8")
 
 

--- a/market_data_validation.py
+++ b/market_data_validation.py
@@ -1,0 +1,422 @@
+"""Strict market-data validation for production forecasts and research runs.
+
+The validator is intentionally independent from TimesFM so it can be exercised
+with lightweight unit tests and reused by Kraken production data, Binance
+backtests, and the weekly optimizer.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol, Sequence
+
+import numpy as np
+
+
+VALIDATION_REPORT_PATH = Path("market_data_validation.json")
+
+
+class MarketDataLike(Protocol):
+    timestamps: Sequence[int]
+    opens: Any
+    highs: Any
+    lows: Any
+    closes: Any
+    volumes: Any
+
+
+@dataclass(frozen=True)
+class ValidationConfig:
+    interval_seconds: int = 3600
+    min_candles: int = 64
+    max_staleness_minutes: float = 90.0
+    future_tolerance_seconds: int = 60
+    max_hourly_return_pct: float = 20.0
+    max_candle_range_pct: float = 30.0
+    max_volume_median_multiplier: float = 50.0
+    volume_lookback: int = 168
+    volume_min_history: int = 24
+
+    @classmethod
+    def from_env(cls) -> "ValidationConfig":
+        """Load conservative thresholds from environment overrides."""
+        return cls(
+            interval_seconds=_env_int("BTC_DATA_INTERVAL_SECONDS", cls.interval_seconds),
+            min_candles=_env_int("BTC_DATA_MIN_CANDLES", cls.min_candles),
+            max_staleness_minutes=_env_float(
+                "BTC_DATA_MAX_STALENESS_MINUTES", cls.max_staleness_minutes
+            ),
+            future_tolerance_seconds=_env_int(
+                "BTC_DATA_FUTURE_TOLERANCE_SECONDS", cls.future_tolerance_seconds
+            ),
+            max_hourly_return_pct=_env_float(
+                "BTC_DATA_MAX_HOURLY_RETURN_PCT", cls.max_hourly_return_pct
+            ),
+            max_candle_range_pct=_env_float(
+                "BTC_DATA_MAX_CANDLE_RANGE_PCT", cls.max_candle_range_pct
+            ),
+            max_volume_median_multiplier=_env_float(
+                "BTC_DATA_MAX_VOLUME_MEDIAN_MULTIPLIER",
+                cls.max_volume_median_multiplier,
+            ),
+            volume_lookback=_env_int("BTC_DATA_VOLUME_LOOKBACK", cls.volume_lookback),
+            volume_min_history=_env_int(
+                "BTC_DATA_VOLUME_MIN_HISTORY", cls.volume_min_history
+            ),
+        )
+
+
+@dataclass
+class ValidationReport:
+    source: str
+    status: str
+    checked_at: str
+    candle_count: int
+    first_timestamp: int | None
+    latest_timestamp: int | None
+    metrics: dict[str, Any]
+    errors: list[dict[str, Any]]
+    config: dict[str, Any]
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class MarketDataValidationError(RuntimeError):
+    def __init__(self, report: ValidationReport):
+        self.report = report
+        codes = ", ".join(error["code"] for error in report.errors)
+        super().__init__(
+            f"Market data validation failed for {report.source}: {codes or 'unknown error'}"
+        )
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None:
+        return float(default)
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise ValueError(f"{name} must be a positive finite number")
+    return parsed
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return int(default)
+    parsed = int(value)
+    if parsed <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return parsed
+
+
+def _iso_timestamp(value: int | None) -> str | None:
+    if value is None:
+        return None
+    return datetime.fromtimestamp(value, tz=timezone.utc).isoformat()
+
+
+def _sample_indices(indices: np.ndarray, limit: int = 5) -> list[int]:
+    return [int(value) for value in indices[:limit]]
+
+
+def _add_error(
+    errors: list[dict[str, Any]],
+    code: str,
+    message: str,
+    *,
+    count: int = 1,
+    samples: list[Any] | None = None,
+) -> None:
+    item: dict[str, Any] = {
+        "code": code,
+        "message": message,
+        "count": int(count),
+    }
+    if samples:
+        item["samples"] = samples
+    errors.append(item)
+
+
+def validate_market_data(
+    data: MarketDataLike,
+    *,
+    source: str,
+    now: datetime | None = None,
+    config: ValidationConfig | None = None,
+    check_staleness: bool = True,
+) -> ValidationReport:
+    """Validate OHLCV structure, cadence, freshness, and hard anomalies.
+
+    Any error makes the report fail and raises ``MarketDataValidationError``.
+    Thresholds are intentionally conservative: they are meant to catch corrupt
+    or clearly implausible inputs, not classify ordinary market volatility.
+    """
+    cfg = config or ValidationConfig.from_env()
+    checked = now or datetime.now(timezone.utc)
+    if checked.tzinfo is None:
+        checked = checked.replace(tzinfo=timezone.utc)
+    checked = checked.astimezone(timezone.utc)
+
+    errors: list[dict[str, Any]] = []
+    metrics: dict[str, Any] = {}
+
+    timestamps = np.asarray(list(data.timestamps), dtype=np.int64)
+    arrays = {
+        "open": np.asarray(data.opens, dtype=np.float64),
+        "high": np.asarray(data.highs, dtype=np.float64),
+        "low": np.asarray(data.lows, dtype=np.float64),
+        "close": np.asarray(data.closes, dtype=np.float64),
+        "volume": np.asarray(data.volumes, dtype=np.float64),
+    }
+
+    lengths = {
+        "timestamps": len(timestamps),
+        **{name: len(values) for name, values in arrays.items()},
+    }
+    unique_lengths = set(lengths.values())
+    if len(unique_lengths) != 1:
+        _add_error(
+            errors,
+            "length_mismatch",
+            f"OHLCV arrays have inconsistent lengths: {lengths}",
+        )
+
+    count = min(lengths.values()) if lengths else 0
+    first_timestamp = int(timestamps[0]) if len(timestamps) else None
+    latest_timestamp = int(timestamps[-1]) if len(timestamps) else None
+
+    if count < cfg.min_candles:
+        _add_error(
+            errors,
+            "insufficient_candles",
+            f"Need at least {cfg.min_candles} candles, got {count}",
+        )
+
+    if len(timestamps):
+        nonpositive_ts = np.where(timestamps <= 0)[0]
+        if len(nonpositive_ts):
+            _add_error(
+                errors,
+                "invalid_timestamp",
+                "Timestamps must be positive Unix seconds",
+                count=len(nonpositive_ts),
+                samples=_sample_indices(nonpositive_ts),
+            )
+
+    for name, values in arrays.items():
+        bad = np.where(~np.isfinite(values))[0]
+        if len(bad):
+            _add_error(
+                errors,
+                f"non_finite_{name}",
+                f"{name} contains NaN or infinity",
+                count=len(bad),
+                samples=_sample_indices(bad),
+            )
+
+    if len(unique_lengths) == 1 and count:
+        opens = arrays["open"]
+        highs = arrays["high"]
+        lows = arrays["low"]
+        closes = arrays["close"]
+        volumes = arrays["volume"]
+
+        for name, values in (
+            ("open", opens),
+            ("high", highs),
+            ("low", lows),
+            ("close", closes),
+        ):
+            bad = np.where(values <= 0)[0]
+            if len(bad):
+                _add_error(
+                    errors,
+                    f"non_positive_{name}",
+                    f"{name} prices must be positive",
+                    count=len(bad),
+                    samples=_sample_indices(bad),
+                )
+
+        bad_volume = np.where(volumes <= 0)[0]
+        if len(bad_volume):
+            _add_error(
+                errors,
+                "non_positive_volume",
+                "Volume must be positive",
+                count=len(bad_volume),
+                samples=_sample_indices(bad_volume),
+            )
+
+        if (
+            np.all(np.isfinite(opens))
+            and np.all(np.isfinite(highs))
+            and np.all(np.isfinite(lows))
+            and np.all(np.isfinite(closes))
+        ):
+            invalid_ohlc = np.where(
+                (highs < opens)
+                | (highs < closes)
+                | (highs < lows)
+                | (lows > opens)
+                | (lows > closes)
+                | (lows > highs)
+            )[0]
+            if len(invalid_ohlc):
+                _add_error(
+                    errors,
+                    "invalid_ohlc",
+                    "OHLC relationship is impossible (high/low do not bound open/close)",
+                    count=len(invalid_ohlc),
+                    samples=_sample_indices(invalid_ohlc),
+                )
+
+            if np.all(closes > 0) and len(closes) > 1:
+                hourly_returns = np.abs(closes[1:] / closes[:-1] - 1.0) * 100.0
+                max_return = float(np.max(hourly_returns))
+                metrics["max_abs_hourly_return_pct"] = round(max_return, 6)
+                extreme = np.where(hourly_returns > cfg.max_hourly_return_pct)[0] + 1
+                if len(extreme):
+                    _add_error(
+                        errors,
+                        "extreme_hourly_return",
+                        "Absolute close-to-close return exceeds "
+                        f"{cfg.max_hourly_return_pct:.2f}%",
+                        count=len(extreme),
+                        samples=_sample_indices(extreme),
+                    )
+
+            if np.all(lows > 0):
+                candle_ranges = (highs / lows - 1.0) * 100.0
+                max_range = float(np.max(candle_ranges))
+                metrics["max_candle_range_pct"] = round(max_range, 6)
+                extreme = np.where(candle_ranges > cfg.max_candle_range_pct)[0]
+                if len(extreme):
+                    _add_error(
+                        errors,
+                        "extreme_candle_range",
+                        f"High-low candle range exceeds {cfg.max_candle_range_pct:.2f}%",
+                        count=len(extreme),
+                        samples=_sample_indices(extreme),
+                    )
+
+        if np.all(np.isfinite(volumes)) and np.all(volumes > 0):
+            max_ratio = 1.0
+            volume_outliers: list[int] = []
+            for index in range(cfg.volume_min_history, len(volumes)):
+                start = max(0, index - cfg.volume_lookback)
+                baseline = float(np.median(volumes[start:index]))
+                if baseline <= 0:
+                    continue
+                ratio = float(volumes[index] / baseline)
+                max_ratio = max(max_ratio, ratio)
+                if ratio > cfg.max_volume_median_multiplier:
+                    volume_outliers.append(index)
+            metrics["max_volume_median_multiplier"] = round(max_ratio, 6)
+            if volume_outliers:
+                _add_error(
+                    errors,
+                    "extreme_volume",
+                    "Volume exceeds rolling-median anomaly threshold "
+                    f"({cfg.max_volume_median_multiplier:.2f}x)",
+                    count=len(volume_outliers),
+                    samples=volume_outliers[:5],
+                )
+
+    if len(timestamps) > 1:
+        diffs = np.diff(timestamps)
+        duplicate = np.where(diffs == 0)[0] + 1
+        out_of_order = np.where(diffs < 0)[0] + 1
+        irregular = np.where(
+            (diffs > 0) & (diffs != cfg.interval_seconds)
+        )[0] + 1
+
+        if len(duplicate):
+            _add_error(
+                errors,
+                "duplicate_timestamp",
+                "Duplicate candle timestamps detected",
+                count=len(duplicate),
+                samples=_sample_indices(duplicate),
+            )
+        if len(out_of_order):
+            _add_error(
+                errors,
+                "out_of_order_timestamp",
+                "Candle timestamps are not strictly increasing",
+                count=len(out_of_order),
+                samples=_sample_indices(out_of_order),
+            )
+        if len(irregular):
+            gaps = [
+                {
+                    "index": int(index),
+                    "previous": _iso_timestamp(int(timestamps[index - 1])),
+                    "current": _iso_timestamp(int(timestamps[index])),
+                    "gap_seconds": int(timestamps[index] - timestamps[index - 1]),
+                }
+                for index in irregular[:5]
+            ]
+            _add_error(
+                errors,
+                "missing_or_irregular_candle",
+                f"Expected exactly {cfg.interval_seconds} seconds between candles",
+                count=len(irregular),
+                samples=gaps,
+            )
+
+    if latest_timestamp is not None:
+        checked_epoch = checked.timestamp()
+        age_seconds = checked_epoch - latest_timestamp
+        metrics["latest_age_seconds"] = round(float(age_seconds), 3)
+        if latest_timestamp > checked_epoch + cfg.future_tolerance_seconds:
+            _add_error(
+                errors,
+                "future_timestamp",
+                "Latest candle timestamp is unexpectedly in the future",
+            )
+        if check_staleness and age_seconds > cfg.max_staleness_minutes * 60.0:
+            _add_error(
+                errors,
+                "stale_data",
+                "Latest completed candle is stale: "
+                f"{age_seconds / 60.0:.1f} minutes old "
+                f"(limit {cfg.max_staleness_minutes:.1f})",
+            )
+
+    report = ValidationReport(
+        source=source,
+        status="failed" if errors else "ok",
+        checked_at=checked.isoformat(),
+        candle_count=count,
+        first_timestamp=first_timestamp,
+        latest_timestamp=latest_timestamp,
+        metrics=metrics,
+        errors=errors,
+        config=asdict(cfg),
+    )
+    if errors:
+        raise MarketDataValidationError(report)
+    return report
+
+
+def persist_validation_report(
+    report: ValidationReport,
+    path: Path = VALIDATION_REPORT_PATH,
+) -> None:
+    path.write_text(json.dumps(report.to_dict(), indent=2) + "\n", encoding="utf-8")
+
+
+def print_validation_report(report: ValidationReport) -> None:
+    print("Market data validation:")
+    print(json.dumps(report.to_dict(), indent=2))

--- a/test_market_data_validation.py
+++ b/test_market_data_validation.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Unit tests for strict OHLCV validation."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+
+from market_data_validation import (
+    MarketDataValidationError,
+    ValidationConfig,
+    validate_market_data,
+)
+
+
+def make_market(count: int = 100):
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    timestamps = [int((base + timedelta(hours=i)).timestamp()) for i in range(count)]
+    closes = np.linspace(100.0, 110.0, count, dtype=np.float64)
+    return SimpleNamespace(
+        timestamps=timestamps,
+        opens=closes - 0.1,
+        highs=closes + 0.5,
+        lows=closes - 0.5,
+        closes=closes,
+        volumes=np.linspace(10.0, 20.0, count, dtype=np.float64),
+    )
+
+
+def current_time_for(data, minutes_after_latest: int = 30) -> datetime:
+    return datetime.fromtimestamp(data.timestamps[-1], tz=timezone.utc) + timedelta(
+        minutes=minutes_after_latest
+    )
+
+
+class MarketDataValidationTests(unittest.TestCase):
+    def test_valid_hourly_market_data_passes(self) -> None:
+        data = make_market()
+        report = validate_market_data(
+            data,
+            source="unit-test",
+            now=current_time_for(data),
+        )
+        self.assertTrue(report.ok)
+        self.assertEqual(report.errors, [])
+        self.assertEqual(report.candle_count, 100)
+
+    def test_duplicate_timestamp_is_rejected(self) -> None:
+        data = make_market()
+        data.timestamps[50] = data.timestamps[49]
+        with self.assertRaises(MarketDataValidationError) as ctx:
+            validate_market_data(data, source="unit-test", now=current_time_for(data))
+        codes = {item["code"] for item in ctx.exception.report.errors}
+        self.assertIn("duplicate_timestamp", codes)
+
+    def test_missing_hour_is_rejected(self) -> None:
+        data = make_market()
+        for index in range(50, len(data.timestamps)):
+            data.timestamps[index] += 3600
+        with self.assertRaises(MarketDataValidationError) as ctx:
+            validate_market_data(data, source="unit-test", now=current_time_for(data))
+        codes = {item["code"] for item in ctx.exception.report.errors}
+        self.assertIn("missing_or_irregular_candle", codes)
+
+    def test_out_of_order_timestamp_is_rejected(self) -> None:
+        data = make_market()
+        data.timestamps[50], data.timestamps[51] = (
+            data.timestamps[51],
+            data.timestamps[50],
+        )
+        with self.assertRaises(MarketDataValidationError) as ctx:
+            validate_market_data(data, source="unit-test", now=current_time_for(data))
+        codes = {item["code"] for item in ctx.exception.report.errors}
+        self.assertIn("out_of_order_timestamp", codes)
+
+    def test_stale_live_data_is_rejected(self) -> None:
+        data = make_market()
+        with self.assertRaises(MarketDataValidationError) as ctx:
+            validate_market_data(
+                data,
+                source="unit-test",
+                now=current_time_for(data, minutes_after_latest=180),
+            )
+        codes = {item["code"] for item in ctx.exception.report.errors}
+        self.assertIn("stale_data", codes)
+
+    def test_historical_data_can_skip_staleness_check(self) -> None:
+        data = make_market()
+        report = validate_market_data(
+            data,
+            source="unit-test",
+            now=current_time_for(data, minutes_after_latest=10_000),
+            check_staleness=False,
+        )
+        self.assertTrue(report.ok)
+
+    def test_impossible_ohlc_is_rejected(self) -> None:
+        data = make_market()
+        data.highs[25] = data.lows[25] - 1.0
+        with self.assertRaises(MarketDataValidationError) as ctx:
+            validate_market_data(data, source="unit-test", now=current_time_for(data))
+        codes = {item["code"] for item in ctx.exception.report.errors}
+        self.assertIn("invalid_ohlc", codes)
+
+    def test_non_positive_price_and_volume_are_rejected(self) -> None:
+        data = make_market()
+        data.closes[20] = 0.0
+        data.volumes[30] = 0.0
+        with self.assertRaises(MarketDataValidationError) as ctx:
+            validate_market_data(data, source="unit-test", now=current_time_for(data))
+        codes = {item["code"] for item in ctx.exception.report.errors}
+        self.assertIn("non_positive_close", codes)
+        self.assertIn("non_positive_volume", codes)
+
+    def test_extreme_price_jump_is_rejected(self) -> None:
+        data = make_market()
+        data.opens[70] = data.closes[69]
+        data.closes[70] = data.closes[69] * 1.30
+        data.highs[70] = data.closes[70] * 1.001
+        data.lows[70] = data.opens[70] * 0.999
+        with self.assertRaises(MarketDataValidationError) as ctx:
+            validate_market_data(data, source="unit-test", now=current_time_for(data))
+        codes = {item["code"] for item in ctx.exception.report.errors}
+        self.assertIn("extreme_hourly_return", codes)
+
+    def test_extreme_volume_is_rejected(self) -> None:
+        data = make_market()
+        data.volumes[80] = np.median(data.volumes[20:80]) * 100.0
+        with self.assertRaises(MarketDataValidationError) as ctx:
+            validate_market_data(data, source="unit-test", now=current_time_for(data))
+        codes = {item["code"] for item in ctx.exception.report.errors}
+        self.assertIn("extreme_volume", codes)
+
+    def test_thresholds_can_be_overridden_from_environment(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "BTC_DATA_MAX_HOURLY_RETURN_PCT": "12.5",
+                "BTC_DATA_MAX_STALENESS_MINUTES": "120",
+            },
+            clear=False,
+        ):
+            config = ValidationConfig.from_env()
+        self.assertEqual(config.max_hourly_return_pct, 12.5)
+        self.assertEqual(config.max_staleness_minutes, 120.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_market_data_validation.py
+++ b/test_market_data_validation.py
@@ -14,6 +14,7 @@ import numpy as np
 from market_data_validation import (
     MarketDataValidationError,
     ValidationConfig,
+    trim_incomplete_trailing_candles,
     validate_market_data,
 )
 
@@ -41,11 +42,7 @@ def current_time_for(data, minutes_after_latest: int = 30) -> datetime:
 class MarketDataValidationTests(unittest.TestCase):
     def test_valid_hourly_market_data_passes(self) -> None:
         data = make_market()
-        report = validate_market_data(
-            data,
-            source="unit-test",
-            now=current_time_for(data),
-        )
+        report = validate_market_data(data, source="unit-test", now=current_time_for(data))
         self.assertTrue(report.ok)
         self.assertEqual(report.errors, [])
         self.assertEqual(report.candle_count, 100)
@@ -55,8 +52,7 @@ class MarketDataValidationTests(unittest.TestCase):
         data.timestamps[50] = data.timestamps[49]
         with self.assertRaises(MarketDataValidationError) as ctx:
             validate_market_data(data, source="unit-test", now=current_time_for(data))
-        codes = {item["code"] for item in ctx.exception.report.errors}
-        self.assertIn("duplicate_timestamp", codes)
+        self.assertIn("duplicate_timestamp", {item["code"] for item in ctx.exception.report.errors})
 
     def test_missing_hour_is_rejected(self) -> None:
         data = make_market()
@@ -64,19 +60,14 @@ class MarketDataValidationTests(unittest.TestCase):
             data.timestamps[index] += 3600
         with self.assertRaises(MarketDataValidationError) as ctx:
             validate_market_data(data, source="unit-test", now=current_time_for(data))
-        codes = {item["code"] for item in ctx.exception.report.errors}
-        self.assertIn("missing_or_irregular_candle", codes)
+        self.assertIn("missing_or_irregular_candle", {item["code"] for item in ctx.exception.report.errors})
 
     def test_out_of_order_timestamp_is_rejected(self) -> None:
         data = make_market()
-        data.timestamps[50], data.timestamps[51] = (
-            data.timestamps[51],
-            data.timestamps[50],
-        )
+        data.timestamps[50], data.timestamps[51] = data.timestamps[51], data.timestamps[50]
         with self.assertRaises(MarketDataValidationError) as ctx:
             validate_market_data(data, source="unit-test", now=current_time_for(data))
-        codes = {item["code"] for item in ctx.exception.report.errors}
-        self.assertIn("out_of_order_timestamp", codes)
+        self.assertIn("out_of_order_timestamp", {item["code"] for item in ctx.exception.report.errors})
 
     def test_stale_live_data_is_rejected(self) -> None:
         data = make_market()
@@ -86,8 +77,7 @@ class MarketDataValidationTests(unittest.TestCase):
                 source="unit-test",
                 now=current_time_for(data, minutes_after_latest=180),
             )
-        codes = {item["code"] for item in ctx.exception.report.errors}
-        self.assertIn("stale_data", codes)
+        self.assertIn("stale_data", {item["code"] for item in ctx.exception.report.errors})
 
     def test_historical_data_can_skip_staleness_check(self) -> None:
         data = make_market()
@@ -99,13 +89,35 @@ class MarketDataValidationTests(unittest.TestCase):
         )
         self.assertTrue(report.ok)
 
+    def test_incomplete_trailing_candle_is_trimmed_for_research(self) -> None:
+        data = make_market()
+        now = current_time_for(data)
+        future_close = int((now + timedelta(minutes=30)).timestamp())
+        data.timestamps.append(future_close)
+        data.opens = np.append(data.opens, data.closes[-1])
+        data.highs = np.append(data.highs, data.closes[-1] + 0.2)
+        data.lows = np.append(data.lows, data.closes[-1] - 0.2)
+        data.closes = np.append(data.closes, data.closes[-1] + 0.1)
+        data.volumes = np.append(data.volumes, data.volumes[-1])
+
+        removed = trim_incomplete_trailing_candles(data, now=now)
+
+        self.assertEqual(removed, 1)
+        self.assertLessEqual(data.timestamps[-1], int(now.timestamp()))
+        report = validate_market_data(
+            data,
+            source="unit-test",
+            now=now,
+            check_staleness=False,
+        )
+        self.assertTrue(report.ok)
+
     def test_impossible_ohlc_is_rejected(self) -> None:
         data = make_market()
         data.highs[25] = data.lows[25] - 1.0
         with self.assertRaises(MarketDataValidationError) as ctx:
             validate_market_data(data, source="unit-test", now=current_time_for(data))
-        codes = {item["code"] for item in ctx.exception.report.errors}
-        self.assertIn("invalid_ohlc", codes)
+        self.assertIn("invalid_ohlc", {item["code"] for item in ctx.exception.report.errors})
 
     def test_non_positive_price_and_volume_are_rejected(self) -> None:
         data = make_market()
@@ -125,16 +137,14 @@ class MarketDataValidationTests(unittest.TestCase):
         data.lows[70] = data.opens[70] * 0.999
         with self.assertRaises(MarketDataValidationError) as ctx:
             validate_market_data(data, source="unit-test", now=current_time_for(data))
-        codes = {item["code"] for item in ctx.exception.report.errors}
-        self.assertIn("extreme_hourly_return", codes)
+        self.assertIn("extreme_hourly_return", {item["code"] for item in ctx.exception.report.errors})
 
     def test_extreme_volume_is_rejected(self) -> None:
         data = make_market()
         data.volumes[80] = np.median(data.volumes[20:80]) * 100.0
         with self.assertRaises(MarketDataValidationError) as ctx:
             validate_market_data(data, source="unit-test", now=current_time_for(data))
-        codes = {item["code"] for item in ctx.exception.report.errors}
-        self.assertIn("extreme_volume", codes)
+        self.assertIn("extreme_volume", {item["code"] for item in ctx.exception.report.errors})
 
     def test_thresholds_can_be_overridden_from_environment(self) -> None:
         with patch.dict(

--- a/validated_entrypoints.py
+++ b/validated_entrypoints.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Validated entrypoints for production forecasts, backtests, and optimization.
+
+This keeps validation at the edge of every automated pipeline without coupling
+TimesFM model code to provider-specific data-quality policy.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from market_data_validation import (
+    MarketDataValidationError,
+    ValidationConfig,
+    persist_validation_report,
+    print_validation_report,
+    validate_market_data,
+)
+
+
+def _validate_and_persist(
+    data: Any,
+    *,
+    source: str,
+    check_staleness: bool,
+) -> Any:
+    try:
+        report = validate_market_data(
+            data,
+            source=source,
+            now=datetime.now(timezone.utc),
+            config=ValidationConfig.from_env(),
+            check_staleness=check_staleness,
+        )
+    except MarketDataValidationError as exc:
+        persist_validation_report(exc.report)
+        print_validation_report(exc.report)
+        raise
+    persist_validation_report(report)
+    print_validation_report(report)
+    return data
+
+
+def run_forecast(argv: list[str]) -> None:
+    if argv:
+        raise SystemExit("forecast does not accept positional arguments")
+    import btc_forecast
+
+    original_fetch = btc_forecast.fetch_kraken_hourly
+
+    def fetch_validated(limit: int = 512):
+        return _validate_and_persist(
+            original_fetch(limit),
+            source="Kraken BTC/USD hourly OHLC",
+            check_staleness=True,
+        )
+
+    btc_forecast.fetch_kraken_hourly = fetch_validated
+    btc_forecast.main()
+
+
+def _patch_backtest_fetch() -> Any:
+    import backtest
+
+    original_fetch = backtest.fetch_binance_history
+
+    def fetch_validated(days: int):
+        return _validate_and_persist(
+            original_fetch(days),
+            source="Binance BTCUSDT hourly klines",
+            check_staleness=False,
+        )
+
+    backtest.fetch_binance_history = fetch_validated
+    return backtest
+
+
+def run_backtest(argv: list[str]) -> None:
+    backtest = _patch_backtest_fetch()
+    sys.argv = [sys.argv[0], *argv]
+    backtest.main()
+
+
+def run_optimizer(argv: list[str]) -> None:
+    # optimizer imports fetch_binance_history directly from backtest, so patch
+    # backtest first and only then import optimizer.
+    _patch_backtest_fetch()
+    import optimizer
+
+    sys.argv = [sys.argv[0], *argv]
+    optimizer.main()
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit(
+            "Usage: python validated_entrypoints.py "
+            "{forecast|backtest|optimizer} [arguments]"
+        )
+
+    command = sys.argv[1]
+    argv = sys.argv[2:]
+    commands: dict[str, Callable[[list[str]], None]] = {
+        "forecast": run_forecast,
+        "backtest": run_backtest,
+        "optimizer": run_optimizer,
+    }
+    try:
+        handler = commands[command]
+    except KeyError as exc:
+        raise SystemExit(f"Unknown command: {command}") from exc
+    handler(argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/validated_entrypoints.py
+++ b/validated_entrypoints.py
@@ -16,6 +16,7 @@ from market_data_validation import (
     ValidationConfig,
     persist_validation_report,
     print_validation_report,
+    trim_incomplete_trailing_candles,
     validate_market_data,
 )
 
@@ -25,7 +26,13 @@ def _validate_and_persist(
     *,
     source: str,
     check_staleness: bool,
+    trim_incomplete: bool = False,
 ) -> Any:
+    removed = (
+        trim_incomplete_trailing_candles(data, now=datetime.now(timezone.utc))
+        if trim_incomplete
+        else 0
+    )
     try:
         report = validate_market_data(
             data,
@@ -35,9 +42,13 @@ def _validate_and_persist(
             check_staleness=check_staleness,
         )
     except MarketDataValidationError as exc:
+        if removed:
+            exc.report.metrics["trimmed_incomplete_candles"] = removed
         persist_validation_report(exc.report)
         print_validation_report(exc.report)
         raise
+    if removed:
+        report.metrics["trimmed_incomplete_candles"] = removed
     persist_validation_report(report)
     print_validation_report(report)
     return data
@@ -71,6 +82,7 @@ def _patch_backtest_fetch() -> Any:
             original_fetch(days),
             source="Binance BTCUSDT hourly klines",
             check_staleness=False,
+            trim_incomplete=True,
         )
 
     backtest.fetch_binance_history = fetch_validated


### PR DESCRIPTION
Implements issue #17.

Adds strict OHLCV validation before automated production forecasts, historical backtests, and weekly optimization. Validation rejects duplicate/missing/out-of-order candles, stale live data, inconsistent OHLC values, non-positive prices/volume, non-finite values, and configurable extreme price/range/volume anomalies. Structured diagnostics are persisted as `market_data_validation.json` and surfaced in Actions summaries/artifacts.

Also adds unit coverage for normal, duplicate, missing, out-of-order, stale, invalid OHLC, non-positive, extreme-price, extreme-volume, and environment-threshold cases.

Closes #17