### PR TITLE
Add forecast history integrity audit and repair tooling

### DIFF
--- a/.github/workflows/history-audit.yml
+++ b/.github/workflows/history-audit.yml
@@ -1,0 +1,65 @@
+name: Forecast history integrity audit
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 5 * * *"
+
+permissions:
+  contents: read
+
+env:
+  HISTORY_RELEASE_TAG: forecast-history-v1
+
+jobs:
+  audit:
+    name: History integrity audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Restore durable forecast database
+        id: restore
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p .state
+          if gh release view "$HISTORY_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release download "$HISTORY_RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern 'forecast_history.sqlite.gz' \
+              --dir .state
+            gzip -df .state/forecast_history.sqlite.gz
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "No durable history release exists yet; nothing to audit."
+          fi
+
+      - name: Audit durable history
+        if: steps.restore.outputs.available == 'true'
+        run: |
+          python history_audit.py \
+            --db .state/forecast_history.sqlite \
+            --report .state/history_audit.json \
+            --fail-on error
+
+      - name: Add audit report to job summary
+        if: always() && steps.restore.outputs.available == 'true' && hashFiles('.state/history_audit.json') != ''
+        run: |
+          echo '## Forecast history integrity audit' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat .state/history_audit.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload audit report
+        if: always() && steps.restore.outputs.available == 'true' && hashFiles('.state/history_audit.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: forecast-history-audit-${{ github.run_id }}
+          path: .state/history_audit.json
+          retention-days: 30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           mypy --follow-imports=skip \
             experiment_manifest.py \
+            history_audit.py \
             history_migrations.py \
             history_store.py \
             market_data_sources.py \

--- a/HISTORY_AUDIT.md
+++ b/HISTORY_AUDIT.md
@@ -1,0 +1,108 @@
+# Forecast history integrity audit
+
+`history_audit.py` validates the durable SQLite forecast-history database without changing it by default.
+
+## What it checks
+
+The audit reports:
+
+- SQLite `integrity_check` and foreign-key violations
+- schema/tables/required columns
+- duplicate logical origins and prediction keys
+- prediction rows whose origin no longer exists
+- underlying model rows without a matching ensemble row
+- invalid required timestamps, prices and market-feature JSON
+- target timestamps that do not equal `origin + horizon`
+- inconsistent `predicted_change_pct`
+- matured rows with missing or inconsistent derived outcome metrics
+- targets older than the maturity grace period that still have no actual outcome
+
+Warnings for missing matured outcomes do not fail the automated workflow by default. Structural/data-integrity errors do.
+
+## Dry-run audit
+
+```bash
+python history_audit.py \
+  --db .state/forecast_history.sqlite \
+  --report .state/history_audit.json
+```
+
+The command prints the same JSON report to stdout. Use `--fail-on warning` to make warnings fail the command, or `--fail-on never` for reporting-only use.
+
+## Safe repair mode
+
+Repair mode only changes deterministic derived fields. It never deletes duplicates, orphan rows or otherwise ambiguous historical records.
+
+```bash
+python history_audit.py \
+  --db .state/forecast_history.sqlite \
+  --repair \
+  --report .state/history_audit.json
+```
+
+Before the first write, the tool creates a byte-for-byte backup next to the database:
+
+```text
+forecast_history.sqlite.pre-repair-YYYYMMDDTHHMMSSZ.bak
+```
+
+Safe repairs include:
+
+- recomputing `target_at` from immutable `origin_at + horizon_hours`
+- recomputing `predicted_change_pct`
+- recomputing derived outcome metrics when the actual target price is already stored
+
+Repairs are idempotent: running repair again on the same healthy database applies zero actions.
+
+## Repair missing matured outcomes
+
+The audit deliberately does not invent or approximate missing actual prices. Provide an explicit exact-target price map when repairing those rows:
+
+```json
+{
+  "2026-09-05T12:00:00+00:00": 111234.56,
+  "1788609600": 111500.00
+}
+```
+
+Then run:
+
+```bash
+python history_audit.py \
+  --db .state/forecast_history.sqlite \
+  --actuals exact_actuals.json \
+  --repair \
+  --report .state/history_audit.json
+```
+
+A list form is also accepted:
+
+```json
+[
+  {
+    "target_at": "2026-09-05T12:00:00+00:00",
+    "actual_target_price_usd": 111234.56
+  }
+]
+```
+
+Only exact target timestamps are used.
+
+## Machine-readable report
+
+The JSON report contains:
+
+- `healthy`
+- severity counts in `summary`
+- actionable entries in `issues`
+- proposed and applied repair actions
+- the repair backup path, when a write occurs
+- SQLite/schema diagnostics
+
+Repair is blocked when structural or required-field errors make automatic mutation unsafe.
+
+## Automated audit
+
+`.github/workflows/history-audit.yml` restores the machine-managed `forecast-history-v1` release asset and runs a dry-run audit every day at **05:17 UTC**. It also supports manual dispatch.
+
+The workflow fails on integrity errors, adds the full JSON report to the job summary and uploads it as a 30-day artifact. Missing matured outcomes remain visible as warnings without blocking the workflow.

--- a/history_audit.py
+++ b/history_audit.py
@@ -159,9 +159,7 @@ def load_actuals(path: Path | str | None) -> dict[int, float]:
             if not isinstance(item, dict):
                 raise ValueError("Actuals list entries must be JSON objects")
             if "target_at" not in item or "actual_target_price_usd" not in item:
-                raise ValueError(
-                    "Actuals entries require target_at and actual_target_price_usd"
-                )
+                raise ValueError("Actuals entries require target_at and actual_target_price_usd")
             add(item["target_at"], item["actual_target_price_usd"])
         return result
     raise ValueError("Actuals JSON must be an object or list")
@@ -187,9 +185,7 @@ def _required_structure(
 
     tables = {
         str(row[0])
-        for row in connection.execute(
-            "SELECT name FROM sqlite_master WHERE type = 'table'"
-        )
+        for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
     }
     report["tables"] = sorted(tables)
     required = {
@@ -243,8 +239,7 @@ def _required_structure(
     missing_columns: list[dict[str, Any]] = []
     for table_name, expected in required_columns.items():
         existing = {
-            str(row["name"])
-            for row in connection.execute(f"PRAGMA table_info({table_name})")
+            str(row["name"]) for row in connection.execute(f"PRAGMA table_info({table_name})")
         }
         missing = sorted(expected - existing)
         if missing:
@@ -455,9 +450,7 @@ def _outcome_metrics(
         "absolute_error_pct": abs(error) / actual * 100.0,
         "signed_error_pct": error / actual * 100.0,
         "actual_change_pct": (actual / source - 1.0) * 100.0,
-        "direction_correct": int(
-            _direction(predicted - source) == _direction(actual - source)
-        ),
+        "direction_correct": int(_direction(predicted - source) == _direction(actual - source)),
         "within_q10_q90": within,
     }
 
@@ -751,11 +744,7 @@ def _apply_repairs(path: Path, report: dict[str, Any], now: datetime) -> None:
         "recompute_outcome_metrics",
         "fill_matured_outcome",
     }
-    actions = [
-        action
-        for action in report["repairs"]["proposed"]
-        if action["action"] in writable
-    ]
+    actions = [action for action in report["repairs"]["proposed"] if action["action"] in writable]
     if not actions:
         return
 
@@ -903,13 +892,10 @@ def audit_database(
         "invalid_origin_fields",
         "invalid_prediction_fields",
     }
-    blockers = sorted(
-        issue["code"] for issue in report["issues"] if issue["code"] in unsafe
-    )
+    blockers = sorted(issue["code"] for issue in report["issues"] if issue["code"] in unsafe)
     if blockers:
         report["repairs"]["blocked_reason"] = (
-            "Automatic repair blocked by structural or ambiguous errors: "
-            + ", ".join(blockers)
+            "Automatic repair blocked by structural or ambiguous errors: " + ", ".join(blockers)
         )
         return _finish(report)
 

--- a/history_audit.py
+++ b/history_audit.py
@@ -12,15 +12,15 @@ import sys
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 from history_migrations import CURRENT_SCHEMA_VERSION
 
 
-AUDIT_REPORT_VERSION = 1
 DEFAULT_DB_PATH = Path(".state/forecast_history.sqlite")
 DEFAULT_GRACE_MINUTES = 15
 ENSEMBLE_MODEL = "ensemble"
+REPORT_VERSION = 1
 
 
 @dataclass(frozen=True)
@@ -30,7 +30,7 @@ class Issue:
     message: str
     count: int = 1
     repairable: bool = False
-    proposed_action: str | None = None
+    action: str | None = None
     examples: list[dict[str, Any]] | None = None
 
     def as_dict(self) -> dict[str, Any]:
@@ -41,24 +41,20 @@ class Issue:
             "count": self.count,
             "repairable": self.repairable,
         }
-        if self.proposed_action:
-            value["proposed_action"] = self.proposed_action
+        if self.action:
+            value["proposed_action"] = self.action
         if self.examples:
             value["examples"] = self.examples
         return value
 
 
-def _utc_now() -> datetime:
-    return datetime.now(timezone.utc)
-
-
-def _parse_timestamp(value: Any) -> datetime:
+def _parse_time(value: Any) -> datetime:
     if not isinstance(value, str) or not value:
         raise ValueError("timestamp must be a non-empty string")
-    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
+    result = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if result.tzinfo is None:
+        result = result.replace(tzinfo=timezone.utc)
+    return result.astimezone(timezone.utc)
 
 
 def _iso(value: datetime) -> str:
@@ -75,7 +71,7 @@ def _finite(value: Any, *, positive: bool = False) -> bool:
     return number > 0 if positive else True
 
 
-def _close(left: Any, right: Any, tolerance: float = 1e-8) -> bool:
+def _close(left: Any, right: Any, tolerance: float = 1e-7) -> bool:
     if left is None or right is None:
         return left is right
     try:
@@ -86,21 +82,17 @@ def _close(left: Any, right: Any, tolerance: float = 1e-8) -> bool:
     return abs(a - b) <= tolerance * max(1.0, abs(a), abs(b))
 
 
-def _direction(value: float, epsilon: float = 1e-9) -> int:
-    if value > epsilon:
+def _direction(value: float) -> int:
+    if value > 1e-9:
         return 1
-    if value < -epsilon:
+    if value < -1e-9:
         return -1
     return 0
 
 
-def _examples(rows: Iterable[sqlite3.Row], limit: int = 5) -> list[dict[str, Any]]:
-    return [dict(row) for index, row in enumerate(rows) if index < limit]
-
-
-def _report(path: Path, mode: str, now: datetime) -> dict[str, Any]:
+def _new_report(path: Path, mode: str, now: datetime) -> dict[str, Any]:
     return {
-        "report_version": AUDIT_REPORT_VERSION,
+        "report_version": REPORT_VERSION,
         "database": str(path),
         "mode": mode,
         "checked_at": _iso(now),
@@ -127,7 +119,7 @@ def _propose(report: dict[str, Any], action: dict[str, Any]) -> None:
     report["repairs"]["proposed"].append(action)
 
 
-def _finalize(report: dict[str, Any]) -> dict[str, Any]:
+def _finish(report: dict[str, Any]) -> dict[str, Any]:
     issues = report["issues"]
     summary = report["summary"]
     summary["errors"] = sum(item["severity"] == "error" for item in issues)
@@ -141,7 +133,7 @@ def _finalize(report: dict[str, Any]) -> dict[str, Any]:
 
 
 def load_actuals(path: Path | str | None) -> dict[int, float]:
-    """Load explicit exact-target prices from a JSON mapping or list."""
+    """Load exact target prices from a JSON mapping or list."""
     if path is None:
         return {}
     payload = json.loads(Path(path).read_text(encoding="utf-8"))
@@ -155,7 +147,7 @@ def load_actuals(path: Path | str | None) -> dict[int, float]:
         elif isinstance(key, str) and key.strip().isdigit():
             timestamp = int(key.strip())
         else:
-            timestamp = int(_parse_timestamp(str(key)).timestamp())
+            timestamp = int(_parse_time(str(key)).timestamp())
         result[timestamp] = float(value)
 
     if isinstance(payload, dict):
@@ -175,7 +167,10 @@ def load_actuals(path: Path | str | None) -> dict[int, float]:
     raise ValueError("Actuals JSON must be an object or list")
 
 
-def _required_structure(connection: sqlite3.Connection, report: dict[str, Any]) -> bool:
+def _required_structure(
+    connection: sqlite3.Connection,
+    report: dict[str, Any],
+) -> bool:
     integrity = [str(row[0]) for row in connection.execute("PRAGMA integrity_check")]
     report["sqlite_integrity"] = integrity
     if integrity != ["ok"]:
@@ -197,13 +192,13 @@ def _required_structure(connection: sqlite3.Connection, report: dict[str, Any]) 
         )
     }
     report["tables"] = sorted(tables)
-    required_tables = {
+    required = {
         "metadata",
         "forecast_origins",
         "forecast_predictions",
         "schema_migrations",
     }
-    missing_tables = sorted(required_tables - tables)
+    missing_tables = sorted(required - tables)
     if missing_tables:
         _add_issue(
             report,
@@ -217,7 +212,7 @@ def _required_structure(connection: sqlite3.Connection, report: dict[str, Any]) 
         )
         return False
 
-    required_columns: dict[str, set[str]] = {
+    required_columns = {
         "forecast_origins": {
             "origin_at",
             "generated_at",
@@ -246,12 +241,12 @@ def _required_structure(connection: sqlite3.Connection, report: dict[str, Any]) 
         },
     }
     missing_columns: list[dict[str, Any]] = []
-    for table_name, expected_columns in required_columns.items():
-        existing_columns = {
+    for table_name, expected in required_columns.items():
+        existing = {
             str(row["name"])
             for row in connection.execute(f"PRAGMA table_info({table_name})")
         }
-        missing = sorted(expected_columns - existing_columns)
+        missing = sorted(expected - existing)
         if missing:
             missing_columns.append({"table": table_name, "columns": missing})
     if missing_columns:
@@ -260,7 +255,7 @@ def _required_structure(connection: sqlite3.Connection, report: dict[str, Any]) 
             Issue(
                 "missing_columns",
                 "error",
-                "History database tables are missing required columns.",
+                "History tables are missing required columns.",
                 sum(len(item["columns"]) for item in missing_columns),
                 examples=missing_columns[:5],
             ),
@@ -275,71 +270,76 @@ def _required_structure(connection: sqlite3.Connection, report: dict[str, Any]) 
             Issue(
                 "schema_version",
                 "error",
-                f"Schema version {version} does not match "
-                f"{CURRENT_SCHEMA_VERSION}; migrate it first.",
+                (
+                    f"Schema version {version} does not match "
+                    f"{CURRENT_SCHEMA_VERSION}; migrate it first."
+                ),
             ),
         )
 
-    foreign_keys = connection.execute("PRAGMA foreign_key_check").fetchall()
-    report["foreign_key_violations"] = len(foreign_keys)
-    if foreign_keys:
+    violations = connection.execute("PRAGMA foreign_key_check").fetchall()
+    report["foreign_key_violations"] = len(violations)
+    if violations:
         _add_issue(
             report,
             Issue(
                 "foreign_key_violation",
                 "error",
-                "Foreign-key violations exist; automatic repair will not delete rows.",
-                len(foreign_keys),
-                examples=_examples(foreign_keys),
+                "Foreign-key violations exist; repair will not delete rows.",
+                len(violations),
+                examples=[dict(row) for row in violations[:5]],
             ),
         )
     return True
 
 
-def _audit_uniqueness(connection: sqlite3.Connection, report: dict[str, Any]) -> None:
-    origins = connection.execute(
-        """
-        SELECT origin_at, COUNT(*) AS duplicate_count
-        FROM forecast_origins
-        GROUP BY origin_at
-        HAVING COUNT(*) > 1
-        """
-    ).fetchall()
-    if origins:
-        _add_issue(
-            report,
-            Issue(
-                "duplicate_origins",
-                "error",
-                "Duplicate logical forecast origins were found.",
-                len(origins),
-                examples=_examples(origins),
-            ),
-        )
+def _audit_duplicates(
+    connection: sqlite3.Connection,
+    report: dict[str, Any],
+) -> None:
+    checks = (
+        (
+            "duplicate_origins",
+            """
+            SELECT origin_at, COUNT(*) AS duplicate_count
+            FROM forecast_origins
+            GROUP BY origin_at
+            HAVING COUNT(*) > 1
+            """,
+            "Duplicate logical forecast origins were found.",
+        ),
+        (
+            "duplicate_predictions",
+            """
+            SELECT origin_at, model_name, horizon_hours,
+                   COUNT(*) AS duplicate_count
+            FROM forecast_predictions
+            GROUP BY origin_at, model_name, horizon_hours
+            HAVING COUNT(*) > 1
+            """,
+            "Duplicate logical prediction keys were found.",
+        ),
+    )
+    for code, query, message in checks:
+        rows = connection.execute(query).fetchall()
+        if rows:
+            _add_issue(
+                report,
+                Issue(
+                    code,
+                    "error",
+                    message,
+                    len(rows),
+                    examples=[dict(row) for row in rows[:5]],
+                ),
+            )
 
-    predictions = connection.execute(
-        """
-        SELECT origin_at, model_name, horizon_hours, COUNT(*) AS duplicate_count
-        FROM forecast_predictions
-        GROUP BY origin_at, model_name, horizon_hours
-        HAVING COUNT(*) > 1
-        """
-    ).fetchall()
-    if predictions:
-        _add_issue(
-            report,
-            Issue(
-                "duplicate_predictions",
-                "error",
-                "Duplicate logical prediction keys were found.",
-                len(predictions),
-                examples=_examples(predictions),
-            ),
-        )
 
-
-def _audit_orphans(connection: sqlite3.Connection, report: dict[str, Any]) -> None:
-    predictions = connection.execute(
+def _audit_orphans(
+    connection: sqlite3.Connection,
+    report: dict[str, Any],
+) -> None:
+    rows = connection.execute(
         """
         SELECT p.origin_at, p.model_name, p.horizon_hours
         FROM forecast_predictions AS p
@@ -348,15 +348,15 @@ def _audit_orphans(connection: sqlite3.Connection, report: dict[str, Any]) -> No
         ORDER BY p.origin_at, p.horizon_hours, p.model_name
         """
     ).fetchall()
-    if predictions:
+    if rows:
         _add_issue(
             report,
             Issue(
                 "orphan_prediction_rows",
                 "error",
-                "Prediction rows reference a missing origin; they are never auto-deleted.",
-                len(predictions),
-                examples=_examples(predictions),
+                "Predictions reference missing origins; rows are never auto-deleted.",
+                len(rows),
+                examples=[dict(row) for row in rows[:5]],
             ),
         )
 
@@ -383,14 +383,17 @@ def _audit_orphans(connection: sqlite3.Connection, report: dict[str, Any]) -> No
             Issue(
                 "orphan_model_groups",
                 "error",
-                "Underlying model rows exist without the matching ensemble row.",
+                "Underlying model rows exist without a matching ensemble row.",
                 len(groups),
-                examples=_examples(groups),
+                examples=[dict(row) for row in groups[:5]],
             ),
         )
 
 
-def _audit_origins(connection: sqlite3.Connection, report: dict[str, Any]) -> None:
+def _audit_origins(
+    connection: sqlite3.Connection,
+    report: dict[str, Any],
+) -> None:
     invalid: list[dict[str, Any]] = []
     rows = connection.execute(
         """
@@ -401,59 +404,61 @@ def _audit_origins(connection: sqlite3.Connection, report: dict[str, Any]) -> No
         """
     ).fetchall()
     for row in rows:
-        row_problems: list[str] = []
-        for column in ("origin_at", "generated_at", "first_seen_at", "last_seen_at"):
+        problems: list[str] = []
+        for column in (
+            "origin_at",
+            "generated_at",
+            "first_seen_at",
+            "last_seen_at",
+        ):
             try:
-                _parse_timestamp(row[column])
+                _parse_time(row[column])
             except (TypeError, ValueError):
-                row_problems.append(f"invalid_{column}")
+                problems.append(f"invalid_{column}")
         if not _finite(row["source_price_usd"], positive=True):
-            row_problems.append("invalid_source_price_usd")
+            problems.append("invalid_source_price_usd")
         try:
             features = json.loads(row["market_features_json"])
             if not isinstance(features, dict):
-                row_problems.append("market_features_json_not_object")
+                problems.append("market_features_json_not_object")
         except (TypeError, json.JSONDecodeError):
-            row_problems.append("invalid_market_features_json")
-        if row_problems:
-            invalid.append({"origin_at": row["origin_at"], "problems": row_problems})
+            problems.append("invalid_market_features_json")
+        if problems:
+            invalid.append({"origin_at": row["origin_at"], "problems": problems})
     if invalid:
         _add_issue(
             report,
             Issue(
                 "invalid_origin_fields",
                 "error",
-                "Forecast-origin rows contain invalid required fields.",
+                "Forecast origins contain invalid required fields.",
                 len(invalid),
                 examples=invalid[:5],
             ),
         )
 
 
-def _expected_outcome(
+def _outcome_metrics(
     row: sqlite3.Row,
-    source_price: float,
+    source: float,
     predicted: float,
     actual: float,
 ) -> dict[str, float | int | None]:
     error = predicted - actual
     q10 = row["q10_usd"]
     q90 = row["q90_usd"]
-    interval = (
-        int(float(q10) <= actual <= float(q90))
-        if q10 is not None and q90 is not None
-        else None
-    )
+    within = None
+    if q10 is not None and q90 is not None:
+        within = int(float(q10) <= actual <= float(q90))
     return {
         "absolute_error_usd": abs(error),
         "absolute_error_pct": abs(error) / actual * 100.0,
         "signed_error_pct": error / actual * 100.0,
-        "actual_change_pct": (actual / source_price - 1.0) * 100.0,
+        "actual_change_pct": (actual / source - 1.0) * 100.0,
         "direction_correct": int(
-            _direction(predicted - source_price)
-            == _direction(actual - source_price)
+            _direction(predicted - source) == _direction(actual - source)
         ),
-        "within_q10_q90": interval,
+        "within_q10_q90": within,
     }
 
 
@@ -462,8 +467,8 @@ def _audit_predictions(
     report: dict[str, Any],
     *,
     now: datetime,
-    maturity_grace_minutes: int,
-    actual_by_timestamp: dict[int, float],
+    grace_minutes: int,
+    actuals: dict[int, float],
 ) -> None:
     rows = connection.execute(
         """
@@ -473,53 +478,46 @@ def _audit_predictions(
         ORDER BY p.origin_at, p.horizon_hours, p.model_name
         """
     ).fetchall()
-
     invalid: list[dict[str, Any]] = []
-    target_mismatches: list[dict[str, Any]] = []
-    change_mismatches: list[dict[str, Any]] = []
-    outcome_mismatches: list[dict[str, Any]] = []
-    missing_matured: list[dict[str, Any]] = []
-    grace = timedelta(minutes=max(0, maturity_grace_minutes))
+    target_errors: list[dict[str, Any]] = []
+    change_errors: list[dict[str, Any]] = []
+    outcome_errors: list[dict[str, Any]] = []
+    missing_outcomes: list[dict[str, Any]] = []
+    grace = timedelta(minutes=max(0, grace_minutes))
 
     for row in rows:
-        row_problems: list[str] = []
-        if not isinstance(row["model_name"], str) or not row["model_name"].strip():
-            row_problems.append("empty_model_name")
-        if not _finite(row["predicted_price_usd"], positive=True):
-            row_problems.append("invalid_predicted_price_usd")
-        if not _finite(row["predicted_change_pct"]):
-            row_problems.append("invalid_predicted_change_pct")
         if row["source_price_usd"] is None:
             continue
-
+        problems: list[str] = []
+        if not isinstance(row["model_name"], str) or not row["model_name"].strip():
+            problems.append("empty_model_name")
+        if not _finite(row["predicted_price_usd"], positive=True):
+            problems.append("invalid_predicted_price_usd")
+        if not _finite(row["predicted_change_pct"]):
+            problems.append("invalid_predicted_change_pct")
         try:
             horizon = int(row["horizon_hours"])
-            origin = _parse_timestamp(row["origin_at"])
-            target = _parse_timestamp(row["target_at"])
+            origin = _parse_time(row["origin_at"])
+            target = _parse_time(row["target_at"])
         except (TypeError, ValueError):
-            row_problems.append("invalid_horizon_or_timestamp")
+            problems.append("invalid_horizon_or_timestamp")
+            horizon = 0
+            origin = now
+            target = now
+        if horizon <= 0:
+            problems.append("invalid_horizon_hours")
+        if row["actual_target_price_usd"] is not None and not _finite(
+            row["actual_target_price_usd"],
+            positive=True,
+        ):
+            problems.append("invalid_actual_target_price_usd")
+        if problems:
             invalid.append(
                 {
                     "origin_at": row["origin_at"],
                     "model_name": row["model_name"],
                     "horizon_hours": row["horizon_hours"],
-                    "problems": row_problems,
-                }
-            )
-            continue
-        if horizon <= 0:
-            row_problems.append("invalid_horizon_hours")
-        if row["actual_target_price_usd"] is not None and not _finite(
-            row["actual_target_price_usd"], positive=True
-        ):
-            row_problems.append("invalid_actual_target_price_usd")
-        if row_problems:
-            invalid.append(
-                {
-                    "origin_at": row["origin_at"],
-                    "model_name": row["model_name"],
-                    "horizon_hours": horizon,
-                    "problems": row_problems,
+                    "problems": sorted(set(problems)),
                 }
             )
             continue
@@ -539,62 +537,61 @@ def _audit_predictions(
                 "stored_target_at": row["target_at"],
                 "expected_target_at": _iso(expected_target),
             }
-            target_mismatches.append(item)
+            target_errors.append(item)
             _propose(report, {"action": "recompute_target_at", **item})
 
         expected_change = (predicted / source - 1.0) * 100.0
-        if not _close(row["predicted_change_pct"], expected_change, 1e-7):
+        if not _close(row["predicted_change_pct"], expected_change):
             item = {
                 **key,
-                "stored_predicted_change_pct": row["predicted_change_pct"],
                 "expected_predicted_change_pct": expected_change,
             }
-            change_mismatches.append(item)
+            change_errors.append(item)
             _propose(report, {"action": "recompute_predicted_change_pct", **item})
 
         actual_value = row["actual_target_price_usd"]
         if actual_value is None:
             if now >= expected_target + grace:
-                supplied = actual_by_timestamp.get(int(expected_target.timestamp()))
+                supplied = actuals.get(int(expected_target.timestamp()))
                 item = {
                     **key,
                     "target_at": _iso(expected_target),
                     "actual_available": supplied is not None,
                 }
-                missing_matured.append(item)
+                missing_outcomes.append(item)
                 if supplied is not None:
                     _propose(
                         report,
                         {
                             "action": "fill_matured_outcome",
                             **item,
-                            "actual_target_price_usd": float(supplied),
+                            "actual_target_price_usd": supplied,
                         },
                     )
             continue
 
         actual = float(actual_value)
-        expected_metrics = _expected_outcome(row, source, predicted, actual)
+        expected = _outcome_metrics(row, source, predicted, actual)
         inconsistent: list[str] = []
-        for column, expected_value in expected_metrics.items():
+        for column, value in expected.items():
             stored = row[column]
-            if expected_value is None:
+            if value is None:
                 if stored is not None:
                     inconsistent.append(column)
             elif column in {"direction_correct", "within_q10_q90"}:
-                if stored is None or int(stored) != int(expected_value):
+                if stored is None or int(stored) != int(value):
                     inconsistent.append(column)
-            elif not _close(stored, expected_value, 1e-7):
+            elif not _close(stored, value):
                 inconsistent.append(column)
         if not row["matured_at"]:
             inconsistent.append("matured_at")
         if inconsistent:
             item = {
                 **key,
-                "fields": sorted(set(inconsistent)),
                 "actual_target_price_usd": actual,
+                "fields": sorted(set(inconsistent)),
             }
-            outcome_mismatches.append(item)
+            outcome_errors.append(item)
             _propose(report, {"action": "recompute_outcome_metrics", **item})
 
     if invalid:
@@ -603,67 +600,65 @@ def _audit_predictions(
             Issue(
                 "invalid_prediction_fields",
                 "error",
-                "Prediction rows contain invalid required fields.",
+                "Predictions contain invalid required fields.",
                 len(invalid),
                 examples=invalid[:5],
             ),
         )
-    if target_mismatches:
+    if target_errors:
         _add_issue(
             report,
             Issue(
                 "target_timestamp_mismatch",
                 "error",
                 "Stored target timestamps do not equal origin + horizon.",
-                len(target_mismatches),
+                len(target_errors),
                 True,
-                "recompute target_at from immutable origin_at + horizon_hours",
-                target_mismatches[:5],
+                "recompute target_at from origin_at + horizon_hours",
+                target_errors[:5],
             ),
         )
-    if change_mismatches:
+    if change_errors:
         _add_issue(
             report,
             Issue(
                 "predicted_change_mismatch",
                 "error",
                 "Stored predicted-change values disagree with stored prices.",
-                len(change_mismatches),
+                len(change_errors),
                 True,
                 "recompute predicted_change_pct",
-                change_mismatches[:5],
+                change_errors[:5],
             ),
         )
-    if outcome_mismatches:
+    if outcome_errors:
         _add_issue(
             report,
             Issue(
                 "incomplete_or_inconsistent_outcome_metrics",
                 "error",
                 "Matured outcomes have missing or inconsistent derived metrics.",
-                len(outcome_mismatches),
+                len(outcome_errors),
                 True,
                 "recompute derived metrics from immutable prices",
-                outcome_mismatches[:5],
+                outcome_errors[:5],
             ),
         )
-    if missing_matured:
-        available = sum(bool(item["actual_available"]) for item in missing_matured)
-        action = (
-            f"fill {available} outcome(s) from supplied exact-target prices"
-            if available
-            else "supply --actuals with exact target timestamps to repair safely"
-        )
+    if missing_outcomes:
+        available = sum(bool(item["actual_available"]) for item in missing_outcomes)
+        action = "supply --actuals with exact target timestamps"
+        if available:
+            action = f"fill {available} outcome(s) from supplied exact-target prices"
         _add_issue(
             report,
             Issue(
                 "missing_matured_outcomes",
                 "warning",
                 "Mature targets still have no stored actual outcome.",
-                len(missing_matured),
+                len(missing_outcomes),
                 available > 0,
                 action,
-                missing_matured[:5],
+                missing_outcomes[:5],
             ),
         )
 
@@ -673,21 +668,21 @@ def _audit(
     report: dict[str, Any],
     *,
     now: datetime,
-    maturity_grace_minutes: int,
-    actual_by_timestamp: dict[int, float],
+    grace_minutes: int,
+    actuals: dict[int, float],
 ) -> None:
     connection.row_factory = sqlite3.Row
     if not _required_structure(connection, report):
         return
-    _audit_uniqueness(connection, report)
+    _audit_duplicates(connection, report)
     _audit_orphans(connection, report)
     _audit_origins(connection, report)
     _audit_predictions(
         connection,
         report,
         now=now,
-        maturity_grace_minutes=maturity_grace_minutes,
-        actual_by_timestamp=actual_by_timestamp,
+        grace_minutes=grace_minutes,
+        actuals=actuals,
     )
 
 
@@ -717,9 +712,9 @@ def _write_outcome(
         raise RuntimeError(f"Prediction disappeared during repair: {key!r}")
     source = float(row["source_price_usd"])
     predicted = float(row["predicted_price_usd"])
-    expected = _expected_outcome(row, source, predicted, actual)
+    expected = _outcome_metrics(row, source, predicted, actual)
     matured_at = row["matured_at"] or _iso(now)
-    sql = """
+    query = """
         UPDATE forecast_predictions
         SET actual_target_price_usd = ?,
             absolute_error_usd = ?,
@@ -732,9 +727,9 @@ def _write_outcome(
         WHERE origin_at = ? AND model_name = ? AND horizon_hours = ?
     """
     if only_if_missing:
-        sql += " AND actual_target_price_usd IS NULL"
+        query += " AND actual_target_price_usd IS NULL"
     return connection.execute(
-        sql,
+        query,
         (
             actual,
             expected["absolute_error_usd"],
@@ -750,14 +745,17 @@ def _write_outcome(
 
 
 def _apply_repairs(path: Path, report: dict[str, Any], now: datetime) -> None:
-    actions = list(report["repairs"]["proposed"])
     writable = {
         "recompute_target_at",
         "recompute_predicted_change_pct",
         "recompute_outcome_metrics",
         "fill_matured_outcome",
     }
-    actions = [action for action in actions if action["action"] in writable]
+    actions = [
+        action
+        for action in report["repairs"]["proposed"]
+        if action["action"] in writable
+    ]
     if not actions:
         return
 
@@ -777,24 +775,30 @@ def _apply_repairs(path: Path, report: dict[str, Any], now: datetime) -> None:
                 str(action["model_name"]),
                 int(action["horizon_hours"]),
             )
-            action_name = action["action"]
-            if action_name == "recompute_target_at":
+            name = action["action"]
+            if name == "recompute_target_at":
                 cursor = connection.execute(
                     """
-                    UPDATE forecast_predictions SET target_at = ?
-                    WHERE origin_at = ? AND model_name = ? AND horizon_hours = ?
+                    UPDATE forecast_predictions
+                    SET target_at = ?
+                    WHERE origin_at = ?
+                      AND model_name = ?
+                      AND horizon_hours = ?
                     """,
                     (action["expected_target_at"], *key),
                 )
-            elif action_name == "recompute_predicted_change_pct":
+            elif name == "recompute_predicted_change_pct":
                 cursor = connection.execute(
                     """
-                    UPDATE forecast_predictions SET predicted_change_pct = ?
-                    WHERE origin_at = ? AND model_name = ? AND horizon_hours = ?
+                    UPDATE forecast_predictions
+                    SET predicted_change_pct = ?
+                    WHERE origin_at = ?
+                      AND model_name = ?
+                      AND horizon_hours = ?
                     """,
                     (float(action["expected_predicted_change_pct"]), *key),
                 )
-            elif action_name == "fill_matured_outcome":
+            elif name == "fill_matured_outcome":
                 cursor = _write_outcome(
                     connection,
                     key,
@@ -807,7 +811,9 @@ def _apply_repairs(path: Path, report: dict[str, Any], now: datetime) -> None:
                     """
                     SELECT actual_target_price_usd
                     FROM forecast_predictions
-                    WHERE origin_at = ? AND model_name = ? AND horizon_hours = ?
+                    WHERE origin_at = ?
+                      AND model_name = ?
+                      AND horizon_hours = ?
                     """,
                     key,
                 ).fetchone()
@@ -841,11 +847,11 @@ def audit_database(
     now: datetime | None = None,
     maturity_grace_minutes: int = DEFAULT_GRACE_MINUTES,
 ) -> dict[str, Any]:
-    """Audit a forecast-history DB and optionally apply conservative repairs."""
+    """Audit a history DB and optionally apply conservative repairs."""
     db_path = Path(path)
-    checked_at = (now or _utc_now()).astimezone(timezone.utc)
+    checked_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     actuals = actual_by_timestamp or {}
-    report = _report(db_path, "repair" if repair else "dry-run", checked_at)
+    report = _new_report(db_path, "repair" if repair else "dry-run", checked_at)
 
     if not db_path.exists() or db_path.stat().st_size == 0:
         _add_issue(
@@ -856,7 +862,7 @@ def audit_database(
                 "Forecast-history database is missing or empty.",
             ),
         )
-        return _finalize(report)
+        return _finish(report)
 
     uri = f"file:{db_path.resolve()}?mode=ro"
     try:
@@ -865,8 +871,8 @@ def audit_database(
                 connection,
                 report,
                 now=checked_at,
-                maturity_grace_minutes=maturity_grace_minutes,
-                actual_by_timestamp=actuals,
+                grace_minutes=maturity_grace_minutes,
+                actuals=actuals,
             )
     except sqlite3.DatabaseError as exc:
         _add_issue(
@@ -877,13 +883,13 @@ def audit_database(
                 f"SQLite could not read the database: {exc}",
             ),
         )
-        return _finalize(report)
+        return _finish(report)
 
-    _finalize(report)
+    _finish(report)
     if not repair:
         return report
 
-    unsafe_codes = {
+    unsafe = {
         "sqlite_integrity",
         "sqlite_read_failure",
         "missing_tables",
@@ -898,27 +904,27 @@ def audit_database(
         "invalid_prediction_fields",
     }
     blockers = sorted(
-        issue["code"] for issue in report["issues"] if issue["code"] in unsafe_codes
+        issue["code"] for issue in report["issues"] if issue["code"] in unsafe
     )
     if blockers:
         report["repairs"]["blocked_reason"] = (
             "Automatic repair blocked by structural or ambiguous errors: "
             + ", ".join(blockers)
         )
-        return _finalize(report)
+        return _finish(report)
 
     _apply_repairs(db_path, report, checked_at)
-    repaired = _report(db_path, "repair", checked_at)
+    repaired = _new_report(db_path, "repair", checked_at)
     repaired["repairs"] = report["repairs"]
     with sqlite3.connect(uri, uri=True) as connection:
         _audit(
             connection,
             repaired,
             now=checked_at,
-            maturity_grace_minutes=maturity_grace_minutes,
-            actual_by_timestamp=actuals,
+            grace_minutes=maturity_grace_minutes,
+            actuals=actuals,
         )
-    return _finalize(repaired)
+    return _finish(repaired)
 
 
 def write_report(report: dict[str, Any], path: Path | str | None) -> None:
@@ -944,7 +950,7 @@ def _exit_code(report: dict[str, Any], fail_on: str) -> int:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Audit and safely repair the durable BTC forecast-history database"
+        description="Audit and safely repair the durable forecast-history database"
     )
     parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH)
     parser.add_argument("--report", type=Path)
@@ -963,12 +969,11 @@ def main() -> None:
     parser.add_argument("--now")
     args = parser.parse_args()
 
-    checked_at = _parse_timestamp(args.now) if args.now else None
-    actuals = load_actuals(args.actuals)
+    checked_at = _parse_time(args.now) if args.now else None
     report = audit_database(
         args.db,
         repair=args.repair,
-        actual_by_timestamp=actuals,
+        actual_by_timestamp=load_actuals(args.actuals),
         now=checked_at,
         maturity_grace_minutes=args.maturity_grace_minutes,
     )

--- a/history_audit.py
+++ b/history_audit.py
@@ -1,0 +1,982 @@
+#!/usr/bin/env python3
+"""Audit and safely repair the durable forecast-history SQLite database."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import shutil
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from history_migrations import CURRENT_SCHEMA_VERSION
+
+
+AUDIT_REPORT_VERSION = 1
+DEFAULT_DB_PATH = Path(".state/forecast_history.sqlite")
+DEFAULT_GRACE_MINUTES = 15
+ENSEMBLE_MODEL = "ensemble"
+
+
+@dataclass(frozen=True)
+class Issue:
+    code: str
+    severity: str
+    message: str
+    count: int = 1
+    repairable: bool = False
+    proposed_action: str | None = None
+    examples: list[dict[str, Any]] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        value: dict[str, Any] = {
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "count": self.count,
+            "repairable": self.repairable,
+        }
+        if self.proposed_action:
+            value["proposed_action"] = self.proposed_action
+        if self.examples:
+            value["examples"] = self.examples
+        return value
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_timestamp(value: Any) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise ValueError("timestamp must be a non-empty string")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _finite(value: Any, *, positive: bool = False) -> bool:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return False
+    if not math.isfinite(number):
+        return False
+    return number > 0 if positive else True
+
+
+def _close(left: Any, right: Any, tolerance: float = 1e-8) -> bool:
+    if left is None or right is None:
+        return left is right
+    try:
+        a = float(left)
+        b = float(right)
+    except (TypeError, ValueError):
+        return False
+    return abs(a - b) <= tolerance * max(1.0, abs(a), abs(b))
+
+
+def _direction(value: float, epsilon: float = 1e-9) -> int:
+    if value > epsilon:
+        return 1
+    if value < -epsilon:
+        return -1
+    return 0
+
+
+def _examples(rows: Iterable[sqlite3.Row], limit: int = 5) -> list[dict[str, Any]]:
+    return [dict(row) for index, row in enumerate(rows) if index < limit]
+
+
+def _report(path: Path, mode: str, now: datetime) -> dict[str, Any]:
+    return {
+        "report_version": AUDIT_REPORT_VERSION,
+        "database": str(path),
+        "mode": mode,
+        "checked_at": _iso(now),
+        "supported_schema_version": CURRENT_SCHEMA_VERSION,
+        "healthy": False,
+        "issues": [],
+        "repairs": {"backup": None, "proposed": [], "applied": []},
+        "summary": {
+            "errors": 0,
+            "warnings": 0,
+            "info": 0,
+            "repairable_issues": 0,
+            "proposed_actions": 0,
+            "applied_actions": 0,
+        },
+    }
+
+
+def _add_issue(report: dict[str, Any], issue: Issue) -> None:
+    report["issues"].append(issue.as_dict())
+
+
+def _propose(report: dict[str, Any], action: dict[str, Any]) -> None:
+    report["repairs"]["proposed"].append(action)
+
+
+def _finalize(report: dict[str, Any]) -> dict[str, Any]:
+    issues = report["issues"]
+    summary = report["summary"]
+    summary["errors"] = sum(item["severity"] == "error" for item in issues)
+    summary["warnings"] = sum(item["severity"] == "warning" for item in issues)
+    summary["info"] = sum(item["severity"] == "info" for item in issues)
+    summary["repairable_issues"] = sum(bool(item["repairable"]) for item in issues)
+    summary["proposed_actions"] = len(report["repairs"]["proposed"])
+    summary["applied_actions"] = len(report["repairs"]["applied"])
+    report["healthy"] = summary["errors"] == 0
+    return report
+
+
+def load_actuals(path: Path | str | None) -> dict[int, float]:
+    """Load explicit exact-target prices from a JSON mapping or list."""
+    if path is None:
+        return {}
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    result: dict[int, float] = {}
+
+    def add(key: Any, value: Any) -> None:
+        if not _finite(value, positive=True):
+            raise ValueError(f"Invalid positive price for {key!r}: {value!r}")
+        if isinstance(key, (int, float)):
+            timestamp = int(key)
+        elif isinstance(key, str) and key.strip().isdigit():
+            timestamp = int(key.strip())
+        else:
+            timestamp = int(_parse_timestamp(str(key)).timestamp())
+        result[timestamp] = float(value)
+
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            add(key, value)
+        return result
+    if isinstance(payload, list):
+        for item in payload:
+            if not isinstance(item, dict):
+                raise ValueError("Actuals list entries must be JSON objects")
+            if "target_at" not in item or "actual_target_price_usd" not in item:
+                raise ValueError(
+                    "Actuals entries require target_at and actual_target_price_usd"
+                )
+            add(item["target_at"], item["actual_target_price_usd"])
+        return result
+    raise ValueError("Actuals JSON must be an object or list")
+
+
+def _required_structure(connection: sqlite3.Connection, report: dict[str, Any]) -> bool:
+    integrity = [str(row[0]) for row in connection.execute("PRAGMA integrity_check")]
+    report["sqlite_integrity"] = integrity
+    if integrity != ["ok"]:
+        _add_issue(
+            report,
+            Issue(
+                "sqlite_integrity",
+                "error",
+                "SQLite integrity_check reported corruption.",
+                len(integrity),
+                examples=[{"message": value} for value in integrity[:5]],
+            ),
+        )
+
+    tables = {
+        str(row[0])
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table'"
+        )
+    }
+    report["tables"] = sorted(tables)
+    required_tables = {
+        "metadata",
+        "forecast_origins",
+        "forecast_predictions",
+        "schema_migrations",
+    }
+    missing_tables = sorted(required_tables - tables)
+    if missing_tables:
+        _add_issue(
+            report,
+            Issue(
+                "missing_tables",
+                "error",
+                "History database is missing required tables.",
+                len(missing_tables),
+                examples=[{"table": name} for name in missing_tables],
+            ),
+        )
+        return False
+
+    required_columns: dict[str, set[str]] = {
+        "forecast_origins": {
+            "origin_at",
+            "generated_at",
+            "source_price_usd",
+            "market_features_json",
+            "first_seen_at",
+            "last_seen_at",
+        },
+        "forecast_predictions": {
+            "origin_at",
+            "model_name",
+            "horizon_hours",
+            "target_at",
+            "predicted_price_usd",
+            "predicted_change_pct",
+            "q10_usd",
+            "q90_usd",
+            "actual_target_price_usd",
+            "absolute_error_usd",
+            "absolute_error_pct",
+            "signed_error_pct",
+            "actual_change_pct",
+            "direction_correct",
+            "within_q10_q90",
+            "matured_at",
+        },
+    }
+    missing_columns: list[dict[str, Any]] = []
+    for table_name, expected_columns in required_columns.items():
+        existing_columns = {
+            str(row["name"])
+            for row in connection.execute(f"PRAGMA table_info({table_name})")
+        }
+        missing = sorted(expected_columns - existing_columns)
+        if missing:
+            missing_columns.append({"table": table_name, "columns": missing})
+    if missing_columns:
+        _add_issue(
+            report,
+            Issue(
+                "missing_columns",
+                "error",
+                "History database tables are missing required columns.",
+                sum(len(item["columns"]) for item in missing_columns),
+                examples=missing_columns[:5],
+            ),
+        )
+        return False
+
+    version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+    report["schema_version"] = version
+    if version != CURRENT_SCHEMA_VERSION:
+        _add_issue(
+            report,
+            Issue(
+                "schema_version",
+                "error",
+                f"Schema version {version} does not match "
+                f"{CURRENT_SCHEMA_VERSION}; migrate it first.",
+            ),
+        )
+
+    foreign_keys = connection.execute("PRAGMA foreign_key_check").fetchall()
+    report["foreign_key_violations"] = len(foreign_keys)
+    if foreign_keys:
+        _add_issue(
+            report,
+            Issue(
+                "foreign_key_violation",
+                "error",
+                "Foreign-key violations exist; automatic repair will not delete rows.",
+                len(foreign_keys),
+                examples=_examples(foreign_keys),
+            ),
+        )
+    return True
+
+
+def _audit_uniqueness(connection: sqlite3.Connection, report: dict[str, Any]) -> None:
+    origins = connection.execute(
+        """
+        SELECT origin_at, COUNT(*) AS duplicate_count
+        FROM forecast_origins
+        GROUP BY origin_at
+        HAVING COUNT(*) > 1
+        """
+    ).fetchall()
+    if origins:
+        _add_issue(
+            report,
+            Issue(
+                "duplicate_origins",
+                "error",
+                "Duplicate logical forecast origins were found.",
+                len(origins),
+                examples=_examples(origins),
+            ),
+        )
+
+    predictions = connection.execute(
+        """
+        SELECT origin_at, model_name, horizon_hours, COUNT(*) AS duplicate_count
+        FROM forecast_predictions
+        GROUP BY origin_at, model_name, horizon_hours
+        HAVING COUNT(*) > 1
+        """
+    ).fetchall()
+    if predictions:
+        _add_issue(
+            report,
+            Issue(
+                "duplicate_predictions",
+                "error",
+                "Duplicate logical prediction keys were found.",
+                len(predictions),
+                examples=_examples(predictions),
+            ),
+        )
+
+
+def _audit_orphans(connection: sqlite3.Connection, report: dict[str, Any]) -> None:
+    predictions = connection.execute(
+        """
+        SELECT p.origin_at, p.model_name, p.horizon_hours
+        FROM forecast_predictions AS p
+        LEFT JOIN forecast_origins AS o USING(origin_at)
+        WHERE o.origin_at IS NULL
+        ORDER BY p.origin_at, p.horizon_hours, p.model_name
+        """
+    ).fetchall()
+    if predictions:
+        _add_issue(
+            report,
+            Issue(
+                "orphan_prediction_rows",
+                "error",
+                "Prediction rows reference a missing origin; they are never auto-deleted.",
+                len(predictions),
+                examples=_examples(predictions),
+            ),
+        )
+
+    groups = connection.execute(
+        """
+        SELECT p.origin_at, p.horizon_hours, COUNT(*) AS model_rows
+        FROM forecast_predictions AS p
+        WHERE p.model_name <> ?
+          AND NOT EXISTS (
+              SELECT 1
+              FROM forecast_predictions AS e
+              WHERE e.origin_at = p.origin_at
+                AND e.horizon_hours = p.horizon_hours
+                AND e.model_name = ?
+          )
+        GROUP BY p.origin_at, p.horizon_hours
+        ORDER BY p.origin_at, p.horizon_hours
+        """,
+        (ENSEMBLE_MODEL, ENSEMBLE_MODEL),
+    ).fetchall()
+    if groups:
+        _add_issue(
+            report,
+            Issue(
+                "orphan_model_groups",
+                "error",
+                "Underlying model rows exist without the matching ensemble row.",
+                len(groups),
+                examples=_examples(groups),
+            ),
+        )
+
+
+def _audit_origins(connection: sqlite3.Connection, report: dict[str, Any]) -> None:
+    invalid: list[dict[str, Any]] = []
+    rows = connection.execute(
+        """
+        SELECT origin_at, generated_at, source_price_usd, market_features_json,
+               first_seen_at, last_seen_at
+        FROM forecast_origins
+        ORDER BY origin_at
+        """
+    ).fetchall()
+    for row in rows:
+        row_problems: list[str] = []
+        for column in ("origin_at", "generated_at", "first_seen_at", "last_seen_at"):
+            try:
+                _parse_timestamp(row[column])
+            except (TypeError, ValueError):
+                row_problems.append(f"invalid_{column}")
+        if not _finite(row["source_price_usd"], positive=True):
+            row_problems.append("invalid_source_price_usd")
+        try:
+            features = json.loads(row["market_features_json"])
+            if not isinstance(features, dict):
+                row_problems.append("market_features_json_not_object")
+        except (TypeError, json.JSONDecodeError):
+            row_problems.append("invalid_market_features_json")
+        if row_problems:
+            invalid.append({"origin_at": row["origin_at"], "problems": row_problems})
+    if invalid:
+        _add_issue(
+            report,
+            Issue(
+                "invalid_origin_fields",
+                "error",
+                "Forecast-origin rows contain invalid required fields.",
+                len(invalid),
+                examples=invalid[:5],
+            ),
+        )
+
+
+def _expected_outcome(
+    row: sqlite3.Row,
+    source_price: float,
+    predicted: float,
+    actual: float,
+) -> dict[str, float | int | None]:
+    error = predicted - actual
+    q10 = row["q10_usd"]
+    q90 = row["q90_usd"]
+    interval = (
+        int(float(q10) <= actual <= float(q90))
+        if q10 is not None and q90 is not None
+        else None
+    )
+    return {
+        "absolute_error_usd": abs(error),
+        "absolute_error_pct": abs(error) / actual * 100.0,
+        "signed_error_pct": error / actual * 100.0,
+        "actual_change_pct": (actual / source_price - 1.0) * 100.0,
+        "direction_correct": int(
+            _direction(predicted - source_price)
+            == _direction(actual - source_price)
+        ),
+        "within_q10_q90": interval,
+    }
+
+
+def _audit_predictions(
+    connection: sqlite3.Connection,
+    report: dict[str, Any],
+    *,
+    now: datetime,
+    maturity_grace_minutes: int,
+    actual_by_timestamp: dict[int, float],
+) -> None:
+    rows = connection.execute(
+        """
+        SELECT p.*, o.source_price_usd
+        FROM forecast_predictions AS p
+        LEFT JOIN forecast_origins AS o USING(origin_at)
+        ORDER BY p.origin_at, p.horizon_hours, p.model_name
+        """
+    ).fetchall()
+
+    invalid: list[dict[str, Any]] = []
+    target_mismatches: list[dict[str, Any]] = []
+    change_mismatches: list[dict[str, Any]] = []
+    outcome_mismatches: list[dict[str, Any]] = []
+    missing_matured: list[dict[str, Any]] = []
+    grace = timedelta(minutes=max(0, maturity_grace_minutes))
+
+    for row in rows:
+        row_problems: list[str] = []
+        if not isinstance(row["model_name"], str) or not row["model_name"].strip():
+            row_problems.append("empty_model_name")
+        if not _finite(row["predicted_price_usd"], positive=True):
+            row_problems.append("invalid_predicted_price_usd")
+        if not _finite(row["predicted_change_pct"]):
+            row_problems.append("invalid_predicted_change_pct")
+        if row["source_price_usd"] is None:
+            continue
+
+        try:
+            horizon = int(row["horizon_hours"])
+            origin = _parse_timestamp(row["origin_at"])
+            target = _parse_timestamp(row["target_at"])
+        except (TypeError, ValueError):
+            row_problems.append("invalid_horizon_or_timestamp")
+            invalid.append(
+                {
+                    "origin_at": row["origin_at"],
+                    "model_name": row["model_name"],
+                    "horizon_hours": row["horizon_hours"],
+                    "problems": row_problems,
+                }
+            )
+            continue
+        if horizon <= 0:
+            row_problems.append("invalid_horizon_hours")
+        if row["actual_target_price_usd"] is not None and not _finite(
+            row["actual_target_price_usd"], positive=True
+        ):
+            row_problems.append("invalid_actual_target_price_usd")
+        if row_problems:
+            invalid.append(
+                {
+                    "origin_at": row["origin_at"],
+                    "model_name": row["model_name"],
+                    "horizon_hours": horizon,
+                    "problems": row_problems,
+                }
+            )
+            continue
+
+        source = float(row["source_price_usd"])
+        predicted = float(row["predicted_price_usd"])
+        expected_target = origin + timedelta(hours=horizon)
+        key = {
+            "origin_at": row["origin_at"],
+            "model_name": row["model_name"],
+            "horizon_hours": horizon,
+        }
+
+        if target != expected_target:
+            item = {
+                **key,
+                "stored_target_at": row["target_at"],
+                "expected_target_at": _iso(expected_target),
+            }
+            target_mismatches.append(item)
+            _propose(report, {"action": "recompute_target_at", **item})
+
+        expected_change = (predicted / source - 1.0) * 100.0
+        if not _close(row["predicted_change_pct"], expected_change, 1e-7):
+            item = {
+                **key,
+                "stored_predicted_change_pct": row["predicted_change_pct"],
+                "expected_predicted_change_pct": expected_change,
+            }
+            change_mismatches.append(item)
+            _propose(report, {"action": "recompute_predicted_change_pct", **item})
+
+        actual_value = row["actual_target_price_usd"]
+        if actual_value is None:
+            if now >= expected_target + grace:
+                supplied = actual_by_timestamp.get(int(expected_target.timestamp()))
+                item = {
+                    **key,
+                    "target_at": _iso(expected_target),
+                    "actual_available": supplied is not None,
+                }
+                missing_matured.append(item)
+                if supplied is not None:
+                    _propose(
+                        report,
+                        {
+                            "action": "fill_matured_outcome",
+                            **item,
+                            "actual_target_price_usd": float(supplied),
+                        },
+                    )
+            continue
+
+        actual = float(actual_value)
+        expected_metrics = _expected_outcome(row, source, predicted, actual)
+        inconsistent: list[str] = []
+        for column, expected_value in expected_metrics.items():
+            stored = row[column]
+            if expected_value is None:
+                if stored is not None:
+                    inconsistent.append(column)
+            elif column in {"direction_correct", "within_q10_q90"}:
+                if stored is None or int(stored) != int(expected_value):
+                    inconsistent.append(column)
+            elif not _close(stored, expected_value, 1e-7):
+                inconsistent.append(column)
+        if not row["matured_at"]:
+            inconsistent.append("matured_at")
+        if inconsistent:
+            item = {
+                **key,
+                "fields": sorted(set(inconsistent)),
+                "actual_target_price_usd": actual,
+            }
+            outcome_mismatches.append(item)
+            _propose(report, {"action": "recompute_outcome_metrics", **item})
+
+    if invalid:
+        _add_issue(
+            report,
+            Issue(
+                "invalid_prediction_fields",
+                "error",
+                "Prediction rows contain invalid required fields.",
+                len(invalid),
+                examples=invalid[:5],
+            ),
+        )
+    if target_mismatches:
+        _add_issue(
+            report,
+            Issue(
+                "target_timestamp_mismatch",
+                "error",
+                "Stored target timestamps do not equal origin + horizon.",
+                len(target_mismatches),
+                True,
+                "recompute target_at from immutable origin_at + horizon_hours",
+                target_mismatches[:5],
+            ),
+        )
+    if change_mismatches:
+        _add_issue(
+            report,
+            Issue(
+                "predicted_change_mismatch",
+                "error",
+                "Stored predicted-change values disagree with stored prices.",
+                len(change_mismatches),
+                True,
+                "recompute predicted_change_pct",
+                change_mismatches[:5],
+            ),
+        )
+    if outcome_mismatches:
+        _add_issue(
+            report,
+            Issue(
+                "incomplete_or_inconsistent_outcome_metrics",
+                "error",
+                "Matured outcomes have missing or inconsistent derived metrics.",
+                len(outcome_mismatches),
+                True,
+                "recompute derived metrics from immutable prices",
+                outcome_mismatches[:5],
+            ),
+        )
+    if missing_matured:
+        available = sum(bool(item["actual_available"]) for item in missing_matured)
+        action = (
+            f"fill {available} outcome(s) from supplied exact-target prices"
+            if available
+            else "supply --actuals with exact target timestamps to repair safely"
+        )
+        _add_issue(
+            report,
+            Issue(
+                "missing_matured_outcomes",
+                "warning",
+                "Mature targets still have no stored actual outcome.",
+                len(missing_matured),
+                available > 0,
+                action,
+                missing_matured[:5],
+            ),
+        )
+
+
+def _audit(
+    connection: sqlite3.Connection,
+    report: dict[str, Any],
+    *,
+    now: datetime,
+    maturity_grace_minutes: int,
+    actual_by_timestamp: dict[int, float],
+) -> None:
+    connection.row_factory = sqlite3.Row
+    if not _required_structure(connection, report):
+        return
+    _audit_uniqueness(connection, report)
+    _audit_orphans(connection, report)
+    _audit_origins(connection, report)
+    _audit_predictions(
+        connection,
+        report,
+        now=now,
+        maturity_grace_minutes=maturity_grace_minutes,
+        actual_by_timestamp=actual_by_timestamp,
+    )
+
+
+def _backup_path(path: Path, now: datetime) -> Path:
+    stamp = now.strftime("%Y%m%dT%H%M%SZ")
+    return path.with_name(f"{path.name}.pre-repair-{stamp}.bak")
+
+
+def _write_outcome(
+    connection: sqlite3.Connection,
+    key: tuple[str, str, int],
+    actual: float,
+    now: datetime,
+    *,
+    only_if_missing: bool,
+) -> sqlite3.Cursor:
+    row = connection.execute(
+        """
+        SELECT p.*, o.source_price_usd
+        FROM forecast_predictions AS p
+        JOIN forecast_origins AS o USING(origin_at)
+        WHERE p.origin_at = ? AND p.model_name = ? AND p.horizon_hours = ?
+        """,
+        key,
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(f"Prediction disappeared during repair: {key!r}")
+    source = float(row["source_price_usd"])
+    predicted = float(row["predicted_price_usd"])
+    expected = _expected_outcome(row, source, predicted, actual)
+    matured_at = row["matured_at"] or _iso(now)
+    sql = """
+        UPDATE forecast_predictions
+        SET actual_target_price_usd = ?,
+            absolute_error_usd = ?,
+            absolute_error_pct = ?,
+            signed_error_pct = ?,
+            actual_change_pct = ?,
+            direction_correct = ?,
+            within_q10_q90 = ?,
+            matured_at = ?
+        WHERE origin_at = ? AND model_name = ? AND horizon_hours = ?
+    """
+    if only_if_missing:
+        sql += " AND actual_target_price_usd IS NULL"
+    return connection.execute(
+        sql,
+        (
+            actual,
+            expected["absolute_error_usd"],
+            expected["absolute_error_pct"],
+            expected["signed_error_pct"],
+            expected["actual_change_pct"],
+            expected["direction_correct"],
+            expected["within_q10_q90"],
+            matured_at,
+            *key,
+        ),
+    )
+
+
+def _apply_repairs(path: Path, report: dict[str, Any], now: datetime) -> None:
+    actions = list(report["repairs"]["proposed"])
+    writable = {
+        "recompute_target_at",
+        "recompute_predicted_change_pct",
+        "recompute_outcome_metrics",
+        "fill_matured_outcome",
+    }
+    actions = [action for action in actions if action["action"] in writable]
+    if not actions:
+        return
+
+    backup = _backup_path(path, now)
+    shutil.copy2(path, backup)
+    report["repairs"]["backup"] = str(backup)
+    applied: list[dict[str, Any]] = []
+
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    try:
+        connection.execute("BEGIN IMMEDIATE")
+        for action in actions:
+            key = (
+                str(action["origin_at"]),
+                str(action["model_name"]),
+                int(action["horizon_hours"]),
+            )
+            action_name = action["action"]
+            if action_name == "recompute_target_at":
+                cursor = connection.execute(
+                    """
+                    UPDATE forecast_predictions SET target_at = ?
+                    WHERE origin_at = ? AND model_name = ? AND horizon_hours = ?
+                    """,
+                    (action["expected_target_at"], *key),
+                )
+            elif action_name == "recompute_predicted_change_pct":
+                cursor = connection.execute(
+                    """
+                    UPDATE forecast_predictions SET predicted_change_pct = ?
+                    WHERE origin_at = ? AND model_name = ? AND horizon_hours = ?
+                    """,
+                    (float(action["expected_predicted_change_pct"]), *key),
+                )
+            elif action_name == "fill_matured_outcome":
+                cursor = _write_outcome(
+                    connection,
+                    key,
+                    float(action["actual_target_price_usd"]),
+                    now,
+                    only_if_missing=True,
+                )
+            else:
+                row = connection.execute(
+                    """
+                    SELECT actual_target_price_usd
+                    FROM forecast_predictions
+                    WHERE origin_at = ? AND model_name = ? AND horizon_hours = ?
+                    """,
+                    key,
+                ).fetchone()
+                if row is None or row["actual_target_price_usd"] is None:
+                    continue
+                cursor = _write_outcome(
+                    connection,
+                    key,
+                    float(row["actual_target_price_usd"]),
+                    now,
+                    only_if_missing=False,
+                )
+            if cursor.rowcount:
+                applied.append(action)
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        connection.close()
+        shutil.copy2(backup, path)
+        raise
+    finally:
+        connection.close()
+    report["repairs"]["applied"] = applied
+
+
+def audit_database(
+    path: Path | str,
+    *,
+    repair: bool = False,
+    actual_by_timestamp: dict[int, float] | None = None,
+    now: datetime | None = None,
+    maturity_grace_minutes: int = DEFAULT_GRACE_MINUTES,
+) -> dict[str, Any]:
+    """Audit a forecast-history DB and optionally apply conservative repairs."""
+    db_path = Path(path)
+    checked_at = (now or _utc_now()).astimezone(timezone.utc)
+    actuals = actual_by_timestamp or {}
+    report = _report(db_path, "repair" if repair else "dry-run", checked_at)
+
+    if not db_path.exists() or db_path.stat().st_size == 0:
+        _add_issue(
+            report,
+            Issue(
+                "database_missing",
+                "error",
+                "Forecast-history database is missing or empty.",
+            ),
+        )
+        return _finalize(report)
+
+    uri = f"file:{db_path.resolve()}?mode=ro"
+    try:
+        with sqlite3.connect(uri, uri=True) as connection:
+            _audit(
+                connection,
+                report,
+                now=checked_at,
+                maturity_grace_minutes=maturity_grace_minutes,
+                actual_by_timestamp=actuals,
+            )
+    except sqlite3.DatabaseError as exc:
+        _add_issue(
+            report,
+            Issue(
+                "sqlite_read_failure",
+                "error",
+                f"SQLite could not read the database: {exc}",
+            ),
+        )
+        return _finalize(report)
+
+    _finalize(report)
+    if not repair:
+        return report
+
+    unsafe_codes = {
+        "sqlite_integrity",
+        "sqlite_read_failure",
+        "missing_tables",
+        "missing_columns",
+        "schema_version",
+        "foreign_key_violation",
+        "duplicate_origins",
+        "duplicate_predictions",
+        "orphan_prediction_rows",
+        "orphan_model_groups",
+        "invalid_origin_fields",
+        "invalid_prediction_fields",
+    }
+    blockers = sorted(
+        issue["code"] for issue in report["issues"] if issue["code"] in unsafe_codes
+    )
+    if blockers:
+        report["repairs"]["blocked_reason"] = (
+            "Automatic repair blocked by structural or ambiguous errors: "
+            + ", ".join(blockers)
+        )
+        return _finalize(report)
+
+    _apply_repairs(db_path, report, checked_at)
+    repaired = _report(db_path, "repair", checked_at)
+    repaired["repairs"] = report["repairs"]
+    with sqlite3.connect(uri, uri=True) as connection:
+        _audit(
+            connection,
+            repaired,
+            now=checked_at,
+            maturity_grace_minutes=maturity_grace_minutes,
+            actual_by_timestamp=actuals,
+        )
+    return _finalize(repaired)
+
+
+def write_report(report: dict[str, Any], path: Path | str | None) -> None:
+    if path is None:
+        return
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _exit_code(report: dict[str, Any], fail_on: str) -> int:
+    if fail_on == "never":
+        return 0
+    if report["summary"]["errors"]:
+        return 2
+    if fail_on == "warning" and report["summary"]["warnings"]:
+        return 2
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Audit and safely repair the durable BTC forecast-history database"
+    )
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH)
+    parser.add_argument("--report", type=Path)
+    parser.add_argument("--actuals", type=Path)
+    parser.add_argument("--repair", action="store_true")
+    parser.add_argument(
+        "--maturity-grace-minutes",
+        type=int,
+        default=DEFAULT_GRACE_MINUTES,
+    )
+    parser.add_argument(
+        "--fail-on",
+        choices=("error", "warning", "never"),
+        default="error",
+    )
+    parser.add_argument("--now")
+    args = parser.parse_args()
+
+    checked_at = _parse_timestamp(args.now) if args.now else None
+    actuals = load_actuals(args.actuals)
+    report = audit_database(
+        args.db,
+        repair=args.repair,
+        actual_by_timestamp=actuals,
+        now=checked_at,
+        maturity_grace_minutes=args.maturity_grace_minutes,
+    )
+    write_report(report, args.report)
+    json.dump(report, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    raise SystemExit(_exit_code(report, args.fail_on))
+
+
+if __name__ == "__main__":
+    main()

--- a/test_history_audit.py
+++ b/test_history_audit.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Tests for forecast-history integrity audit and repair tooling."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from history_audit import audit_database, load_actuals
+
+
+SCHEMA_SQL = """
+CREATE TABLE metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+CREATE TABLE forecast_origins (
+    origin_at TEXT PRIMARY KEY,
+    generated_at TEXT NOT NULL,
+    source_name TEXT,
+    pair TEXT,
+    source_price_usd REAL NOT NULL,
+    regime TEXT,
+    market_features_json TEXT NOT NULL,
+    first_seen_at TEXT NOT NULL,
+    last_seen_at TEXT NOT NULL
+);
+CREATE TABLE forecast_predictions (
+    origin_at TEXT NOT NULL,
+    model_name TEXT NOT NULL,
+    horizon_hours INTEGER NOT NULL CHECK (horizon_hours > 0),
+    target_at TEXT NOT NULL,
+    predicted_price_usd REAL NOT NULL,
+    predicted_change_pct REAL NOT NULL,
+    q10_usd REAL,
+    q50_usd REAL,
+    q90_usd REAL,
+    model_agreement REAL,
+    ensemble_weight REAL,
+    actual_target_price_usd REAL,
+    absolute_error_usd REAL,
+    absolute_error_pct REAL,
+    signed_error_pct REAL,
+    actual_change_pct REAL,
+    direction_correct INTEGER,
+    within_q10_q90 INTEGER,
+    matured_at TEXT,
+    PRIMARY KEY (origin_at, model_name, horizon_hours),
+    FOREIGN KEY (origin_at) REFERENCES forecast_origins(origin_at) ON DELETE CASCADE
+);
+CREATE TABLE schema_migrations (
+    version INTEGER PRIMARY KEY CHECK (version > 0),
+    name TEXT NOT NULL,
+    applied_at TEXT NOT NULL
+);
+"""
+
+
+class HistoryAuditTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.db = Path(self.tmp.name) / "history.sqlite"
+        self.origin = datetime(2026, 9, 1, 12, tzinfo=timezone.utc)
+        self.now = self.origin + timedelta(hours=24)
+        self._create_database()
+        self._insert_origin(self.origin)
+        for model in ("ensemble", "timesfm_168h", "persistence"):
+            self._insert_prediction(self.origin, model, 2)
+            self._insert_prediction(self.origin, model, 4)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _create_database(self) -> None:
+        with sqlite3.connect(self.db) as connection:
+            connection.executescript(SCHEMA_SQL)
+            connection.execute("PRAGMA user_version = 2")
+            connection.execute(
+                "INSERT INTO metadata(key, value) VALUES('schema_version', '2')"
+            )
+            connection.executemany(
+                """
+                INSERT INTO schema_migrations(version, name, applied_at)
+                VALUES (?, ?, ?)
+                """,
+                [
+                    (1, "initial_history_schema", self.origin.isoformat()),
+                    (2, "add_migration_audit", self.origin.isoformat()),
+                ],
+            )
+
+    def _insert_origin(self, origin: datetime, source_price: float = 100.0) -> None:
+        with sqlite3.connect(self.db) as connection:
+            connection.execute(
+                """
+                INSERT INTO forecast_origins(
+                    origin_at, generated_at, source_name, pair, source_price_usd,
+                    regime, market_features_json, first_seen_at, last_seen_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    origin.isoformat(),
+                    (origin + timedelta(minutes=2)).isoformat(),
+                    "Kraken",
+                    "BTC/USD",
+                    source_price,
+                    "range",
+                    json.dumps({"rsi_14": 50.0}),
+                    origin.isoformat(),
+                    origin.isoformat(),
+                ),
+            )
+
+    def _insert_prediction(self, origin: datetime, model: str, horizon: int) -> None:
+        source = 100.0
+        predicted = source + horizon
+        with sqlite3.connect(self.db) as connection:
+            connection.execute(
+                """
+                INSERT INTO forecast_predictions(
+                    origin_at, model_name, horizon_hours, target_at,
+                    predicted_price_usd, predicted_change_pct,
+                    q10_usd, q50_usd, q90_usd, model_agreement, ensemble_weight
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    origin.isoformat(),
+                    model,
+                    horizon,
+                    (origin + timedelta(hours=horizon)).isoformat(),
+                    predicted,
+                    (predicted / source - 1.0) * 100.0,
+                    95.0 if model == "ensemble" else None,
+                    predicted if model == "ensemble" else None,
+                    110.0 if model == "ensemble" else None,
+                    0.8 if model == "ensemble" else None,
+                    None if model == "ensemble" else 0.5,
+                ),
+            )
+
+    def _actuals(self) -> dict[int, float]:
+        return {
+            int((self.origin + timedelta(hours=2)).timestamp()): 101.0,
+            int((self.origin + timedelta(hours=4)).timestamp()): 104.0,
+        }
+
+    def _mature_all(self) -> None:
+        result = audit_database(
+            self.db,
+            repair=True,
+            actual_by_timestamp=self._actuals(),
+            now=self.now,
+        )
+        self.assertEqual(result["summary"]["errors"], 0)
+        self.assertEqual(result["summary"]["warnings"], 0)
+
+    def test_healthy_database_has_no_issues_after_outcomes_mature(self) -> None:
+        self._mature_all()
+        report = audit_database(self.db, now=self.now)
+        self.assertTrue(report["healthy"])
+        self.assertEqual(report["summary"]["errors"], 0)
+        self.assertEqual(report["summary"]["warnings"], 0)
+        self.assertEqual(report["sqlite_integrity"], ["ok"])
+
+    def test_dry_run_reports_missing_outcomes_without_writing(self) -> None:
+        report = audit_database(
+            self.db,
+            now=self.now,
+            actual_by_timestamp=self._actuals(),
+        )
+        issue = next(
+            item
+            for item in report["issues"]
+            if item["code"] == "missing_matured_outcomes"
+        )
+        self.assertEqual(issue["severity"], "warning")
+        self.assertTrue(issue["repairable"])
+        self.assertEqual(report["summary"]["applied_actions"], 0)
+        with sqlite3.connect(self.db) as connection:
+            matured = connection.execute(
+                """
+                SELECT COUNT(*) FROM forecast_predictions
+                WHERE actual_target_price_usd IS NOT NULL
+                """
+            ).fetchone()[0]
+        self.assertEqual(matured, 0)
+
+    def test_repair_is_backed_up_and_idempotent(self) -> None:
+        first = audit_database(
+            self.db,
+            repair=True,
+            actual_by_timestamp=self._actuals(),
+            now=self.now,
+        )
+        self.assertIsNotNone(first["repairs"]["backup"])
+        self.assertEqual(first["summary"]["applied_actions"], 6)
+        self.assertTrue(first["healthy"])
+
+        second = audit_database(
+            self.db,
+            repair=True,
+            actual_by_timestamp=self._actuals(),
+            now=self.now,
+        )
+        self.assertEqual(second["summary"]["applied_actions"], 0)
+        self.assertIsNone(second["repairs"]["backup"])
+
+    def test_safe_derived_fields_are_repaired(self) -> None:
+        self._mature_all()
+        with sqlite3.connect(self.db) as connection:
+            connection.execute(
+                """
+                UPDATE forecast_predictions
+                SET target_at = ?,
+                    predicted_change_pct = 999.0,
+                    absolute_error_pct = NULL,
+                    direction_correct = NULL,
+                    matured_at = NULL
+                WHERE origin_at = ?
+                  AND model_name = 'ensemble'
+                  AND horizon_hours = 2
+                """,
+                (
+                    (self.origin + timedelta(hours=3)).isoformat(),
+                    self.origin.isoformat(),
+                ),
+            )
+
+        dry_run = audit_database(self.db, now=self.now)
+        codes = {item["code"] for item in dry_run["issues"]}
+        self.assertIn("target_timestamp_mismatch", codes)
+        self.assertIn("predicted_change_mismatch", codes)
+        self.assertIn("incomplete_or_inconsistent_outcome_metrics", codes)
+
+        repaired = audit_database(self.db, repair=True, now=self.now)
+        self.assertTrue(repaired["healthy"])
+        self.assertGreaterEqual(repaired["summary"]["applied_actions"], 3)
+
+    def test_orphan_prediction_blocks_repair_and_is_not_deleted(self) -> None:
+        with sqlite3.connect(self.db) as connection:
+            connection.execute("PRAGMA foreign_keys = OFF")
+            connection.execute(
+                """
+                INSERT INTO forecast_predictions(
+                    origin_at, model_name, horizon_hours, target_at,
+                    predicted_price_usd, predicted_change_pct
+                ) VALUES (?, 'timesfm_orphan', 2, ?, 100.0, 0.0)
+                """,
+                (
+                    "2026-08-01T00:00:00+00:00",
+                    "2026-08-01T02:00:00+00:00",
+                ),
+            )
+
+        report = audit_database(self.db, repair=True, now=self.now)
+        codes = {item["code"] for item in report["issues"]}
+        self.assertIn("foreign_key_violation", codes)
+        self.assertIn("orphan_prediction_rows", codes)
+        self.assertIn("blocked_reason", report["repairs"])
+        with sqlite3.connect(self.db) as connection:
+            count = connection.execute(
+                """
+                SELECT COUNT(*) FROM forecast_predictions
+                WHERE model_name = 'timesfm_orphan'
+                """
+            ).fetchone()[0]
+        self.assertEqual(count, 1)
+
+    def test_orphan_model_group_is_detected(self) -> None:
+        second_origin = self.origin + timedelta(hours=6)
+        self._insert_origin(second_origin)
+        self._insert_prediction(second_origin, "timesfm_168h", 2)
+        report = audit_database(self.db, now=self.now)
+        issue = next(
+            item for item in report["issues"] if item["code"] == "orphan_model_groups"
+        )
+        self.assertEqual(issue["severity"], "error")
+        self.assertEqual(issue["count"], 1)
+
+    def test_invalid_required_origin_field_is_detected(self) -> None:
+        with sqlite3.connect(self.db) as connection:
+            connection.execute(
+                """
+                UPDATE forecast_origins
+                SET market_features_json = 'not-json'
+                WHERE origin_at = ?
+                """,
+                (self.origin.isoformat(),),
+            )
+        report = audit_database(self.db, now=self.now)
+        issue = next(
+            item for item in report["issues"] if item["code"] == "invalid_origin_fields"
+        )
+        self.assertEqual(issue["severity"], "error")
+        self.assertIn("invalid_market_features_json", issue["examples"][0]["problems"])
+
+    def test_actuals_loader_accepts_iso_and_unix_keys(self) -> None:
+        path = Path(self.tmp.name) / "actuals.json"
+        iso = (self.origin + timedelta(hours=2)).isoformat()
+        unix = int((self.origin + timedelta(hours=4)).timestamp())
+        path.write_text(json.dumps({iso: 101.0, str(unix): 104.0}), encoding="utf-8")
+        loaded = load_actuals(path)
+        iso_timestamp = int((self.origin + timedelta(hours=2)).timestamp())
+        self.assertEqual(loaded[iso_timestamp], 101.0)
+        self.assertEqual(loaded[unix], 104.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_history_audit.py
+++ b/test_history_audit.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from history_audit import audit_database, load_actuals
+from history_migrations import CURRENT_SCHEMA_VERSION
 
 
 SCHEMA_SQL = """
@@ -78,9 +79,10 @@ class HistoryAuditTests(unittest.TestCase):
     def _create_database(self) -> None:
         with sqlite3.connect(self.db) as connection:
             connection.executescript(SCHEMA_SQL)
-            connection.execute("PRAGMA user_version = 2")
+            connection.execute(f"PRAGMA user_version = {CURRENT_SCHEMA_VERSION}")
             connection.execute(
-                "INSERT INTO metadata(key, value) VALUES('schema_version', '2')"
+                "INSERT INTO metadata(key, value) VALUES('schema_version', ?)",
+                (str(CURRENT_SCHEMA_VERSION),),
             )
             connection.executemany(
                 """
@@ -88,8 +90,8 @@ class HistoryAuditTests(unittest.TestCase):
                 VALUES (?, ?, ?)
                 """,
                 [
-                    (1, "initial_history_schema", self.origin.isoformat()),
-                    (2, "add_migration_audit", self.origin.isoformat()),
+                    (version, f"fixture_v{version}", self.origin.isoformat())
+                    for version in range(1, CURRENT_SCHEMA_VERSION + 1)
                 ],
             )
 
@@ -173,9 +175,7 @@ class HistoryAuditTests(unittest.TestCase):
             actual_by_timestamp=self._actuals(),
         )
         issue = next(
-            item
-            for item in report["issues"]
-            if item["code"] == "missing_matured_outcomes"
+            item for item in report["issues"] if item["code"] == "missing_matured_outcomes"
         )
         self.assertEqual(issue["severity"], "warning")
         self.assertTrue(issue["repairable"])
@@ -275,9 +275,7 @@ class HistoryAuditTests(unittest.TestCase):
         self._insert_origin(second_origin)
         self._insert_prediction(second_origin, "timesfm_168h", 2)
         report = audit_database(self.db, now=self.now)
-        issue = next(
-            item for item in report["issues"] if item["code"] == "orphan_model_groups"
-        )
+        issue = next(item for item in report["issues"] if item["code"] == "orphan_model_groups")
         self.assertEqual(issue["severity"], "error")
         self.assertEqual(issue["count"], 1)
 
@@ -292,9 +290,7 @@ class HistoryAuditTests(unittest.TestCase):
                 (self.origin.isoformat(),),
             )
         report = audit_database(self.db, now=self.now)
-        issue = next(
-            item for item in report["issues"] if item["code"] == "invalid_origin_fields"
-        )
+        issue = next(item for item in report["issues"] if item["code"] == "invalid_origin_fields")
         self.assertEqual(issue["severity"], "error")
         self.assertIn("invalid_market_features_json", issue["examples"][0]["problems"])
 

--- a/test_history_audit.py
+++ b/test_history_audit.py
@@ -276,9 +276,7 @@ class HistoryAuditTests(unittest.TestCase):
         self._insert_origin(second_origin)
         self._insert_prediction(second_origin, "timesfm_168h", 2)
         report = audit_database(self.db, now=self.now)
-        issue = next(
-            item for item in report["issues"] if item["code"] == "orphan_model_groups"
-        )
+        issue = next(item for item in report["issues"] if item["code"] == "orphan_model_groups")
         self.assertEqual(issue["severity"], "error")
         self.assertEqual(issue["count"], 1)
 
@@ -293,9 +291,7 @@ class HistoryAuditTests(unittest.TestCase):
                 (self.origin.isoformat(),),
             )
         report = audit_database(self.db, now=self.now)
-        issue = next(
-            item for item in report["issues"] if item["code"] == "invalid_origin_fields"
-        )
+        issue = next(item for item in report["issues"] if item["code"] == "invalid_origin_fields")
         self.assertEqual(issue["severity"], "error")
         self.assertIn("invalid_market_features_json", issue["examples"][0]["problems"])
 

--- a/test_history_audit.py
+++ b/test_history_audit.py
@@ -157,8 +157,9 @@ class HistoryAuditTests(unittest.TestCase):
             actual_by_timestamp=self._actuals(),
             now=self.now,
         )
-        self.assertEqual(result["summary"]["errors"], 0)
-        self.assertEqual(result["summary"]["warnings"], 0)
+        message = json.dumps(result, indent=2, sort_keys=True)
+        self.assertEqual(result["summary"]["errors"], 0, message)
+        self.assertEqual(result["summary"]["warnings"], 0, message)
 
     def test_healthy_database_has_no_issues_after_outcomes_mature(self) -> None:
         self._mature_all()
@@ -196,7 +197,7 @@ class HistoryAuditTests(unittest.TestCase):
             actual_by_timestamp=self._actuals(),
             now=self.now,
         )
-        self.assertIsNotNone(first["repairs"]["backup"])
+        self.assertIsNotNone(first["repairs"]["backup"], json.dumps(first, indent=2))
         self.assertEqual(first["summary"]["applied_actions"], 6)
         self.assertTrue(first["healthy"])
 
@@ -275,7 +276,9 @@ class HistoryAuditTests(unittest.TestCase):
         self._insert_origin(second_origin)
         self._insert_prediction(second_origin, "timesfm_168h", 2)
         report = audit_database(self.db, now=self.now)
-        issue = next(item for item in report["issues"] if item["code"] == "orphan_model_groups")
+        issue = next(
+            item for item in report["issues"] if item["code"] == "orphan_model_groups"
+        )
         self.assertEqual(issue["severity"], "error")
         self.assertEqual(issue["count"], 1)
 
@@ -290,7 +293,9 @@ class HistoryAuditTests(unittest.TestCase):
                 (self.origin.isoformat(),),
             )
         report = audit_database(self.db, now=self.now)
-        issue = next(item for item in report["issues"] if item["code"] == "invalid_origin_fields")
+        issue = next(
+            item for item in report["issues"] if item["code"] == "invalid_origin_fields"
+        )
         self.assertEqual(issue["severity"], "error")
         self.assertIn("invalid_market_features_json", issue["examples"][0]["problems"])
 


### PR DESCRIPTION
## Summary
- add `history_audit.py` with machine-readable dry-run integrity reports
- detect SQLite/schema/foreign-key problems, duplicates, missing required fields, orphan prediction/model rows, missing matured outcomes, and inconsistent derived fields
- add conservative `--repair` mode with automatic byte-for-byte backup and no destructive deletion
- allow exact target prices to be supplied explicitly for safe repair of missing matured outcomes
- add daily/manual GitHub Actions history audit with JSON artifact and error gating
- add unit coverage for healthy, incomplete, inconsistent, and orphaned/corrupted fixtures
- type-check the new audit module and document operator usage in `HISTORY_AUDIT.md`

Repairs are idempotent and structural corruption blocks automatic mutation.

Closes #20