### PR TITLE
Add forecast performance dashboard

### DIFF
--- a/.github/workflows/performance-dashboard.yml
+++ b/.github/workflows/performance-dashboard.yml
@@ -1,0 +1,55 @@
+name: Forecast performance dashboard
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 05 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  dashboard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Restore durable forecast history
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p .state
+          gh release download forecast-history-v1 \
+            --pattern forecast_history.sqlite.gz \
+            --output .state/forecast_history.sqlite.gz
+          gzip -dc .state/forecast_history.sqlite.gz > .state/forecast_history.sqlite
+
+      - name: Verify durable history
+        run: python history_store.py --db .state/forecast_history.sqlite verify
+
+      - name: Generate dashboard
+        run: |
+          mkdir -p dashboard
+          python performance_dashboard.py \
+            --db .state/forecast_history.sqlite \
+            --json dashboard/performance_dashboard.json \
+            --markdown dashboard/performance_dashboard.md \
+            --html dashboard/performance_dashboard.html
+
+      - name: Add dashboard to Actions summary
+        run: cat dashboard/performance_dashboard.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload dashboard artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: forecast-performance-dashboard
+          path: dashboard/
+          retention-days: 90

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,5 +95,6 @@ jobs:
             market_data_sources.py \
             market_data_validation.py \
             observability.py \
+            performance_dashboard.py \
             schedule_guard.py \
             statistical_significance.py

--- a/PERFORMANCE_DASHBOARD.md
+++ b/PERFORMANCE_DASHBOARD.md
@@ -1,0 +1,61 @@
+# Forecast performance dashboard
+
+`performance_dashboard.py` generates an operator-friendly view of production forecast quality directly from the durable SQLite history database. No CSV preprocessing or manual joins are required.
+
+## Metrics
+
+The dashboard reports, separately for every 2h, 4h, 8h and 16h horizon:
+
+- mean absolute percentage error (MAE)
+- mean signed error percentage (bias)
+- direction accuracy
+- Q10-Q90 interval coverage when a model emitted interval bounds
+- matured sample count and interval sample count
+
+The ensemble, every persisted individual model, and `persistence` are shown side by side. Persistence is always rendered as a required baseline even when no persisted samples are available, in which case the report flags `no_samples`.
+
+## Segmentation
+
+Every metric is regenerated for:
+
+- all available history
+- rolling 7-day, 30-day and 90-day windows by default
+- each persisted market regime inside every window and horizon
+
+The rolling windows can be overridden with `--rolling-days`, for example `--rolling-days 14,60,180`.
+
+## Confidence warnings
+
+Segments with fewer than 20 matured observations are marked as low confidence by default. The threshold is configurable with `--low-sample-threshold`. Missing segments are marked `no_samples`.
+
+These warnings are descriptive; they do not alter forecasts or adaptive weights.
+
+## Generate locally
+
+```bash
+python performance_dashboard.py \
+  --db .state/forecast_history.sqlite \
+  --json performance_dashboard.json \
+  --markdown performance_dashboard.md \
+  --html performance_dashboard.html
+```
+
+The command verifies the durable database before reading it. A failed database verification stops dashboard generation rather than publishing misleading metrics.
+
+Outputs:
+
+- `performance_dashboard.json`: machine-readable metrics and warnings
+- `performance_dashboard.md`: GitHub/terminal-friendly report
+- `performance_dashboard.html`: standalone static dashboard with expandable regime tables
+
+## Automation
+
+`.github/workflows/performance-dashboard.yml` runs daily and on manual dispatch. It downloads the canonical `forecast_history.sqlite.gz` asset from the private `forecast-history-v1` GitHub Release, verifies/decompresses it, regenerates all three dashboard formats, appends the Markdown report to the Actions job summary, and uploads the dashboard files as a 90-day workflow artifact.
+
+The workflow requires only the repository `GITHUB_TOKEN` with read access. It does not post to X and does not modify forecast history.
+
+## Interpretation
+
+MAE answers how far predictions were from the realized price on average. Signed bias shows systematic over- or under-prediction. Direction accuracy measures whether the model correctly predicted the sign of the move from the origin close. Q10-Q90 coverage measures calibration only for observations where interval bounds were stored.
+
+Always compare the ensemble with persistence before treating a lower MAE as meaningful. Low-sample segments should be considered preliminary until the warning clears.

--- a/performance_dashboard.py
+++ b/performance_dashboard.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Generate forecast-performance dashboard artifacts from durable history."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from history_store import DEFAULT_DB_PATH, ENSEMBLE_MODEL, ForecastHistoryStore
+
+DEFAULT_HORIZONS = (2, 4, 8, 16)
+DEFAULT_ROLLING_DAYS = (7, 30, 90)
+DEFAULT_LOW_SAMPLE_THRESHOLD = 20
+PERSISTENCE_MODEL = "persistence"
+
+
+def _parse_timestamp(value: Any) -> datetime:
+    if not isinstance(value, str) or not value:
+        raise ValueError("timestamp must be a non-empty string")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _safe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _mean(values: Iterable[float]) -> float | None:
+    items = list(values)
+    if not items:
+        return None
+    return sum(items) / len(items)
+
+
+def _round(value: float | None, digits: int = 4) -> float | None:
+    return round(value, digits) if value is not None else None
+
+
+def _metric_summary(rows: list[dict[str, Any]], low_sample_threshold: int) -> dict[str, Any]:
+    samples = len(rows)
+    interval_values = [
+        float(value)
+        for row in rows
+        if (value := _safe_float(row.get("within_q10_q90"))) is not None
+    ]
+    warning: str | None = None
+    if samples == 0:
+        warning = "no_samples"
+    elif samples < low_sample_threshold:
+        warning = f"low_sample_count:{samples}<{low_sample_threshold}"
+
+    return {
+        "samples": samples,
+        "mae_pct": _round(
+            _mean(
+                value
+                for row in rows
+                if (value := _safe_float(row.get("absolute_error_pct"))) is not None
+            )
+        ),
+        "mean_signed_error_pct": _round(
+            _mean(
+                value
+                for row in rows
+                if (value := _safe_float(row.get("signed_error_pct"))) is not None
+            )
+        ),
+        "direction_accuracy": _round(
+            _mean(
+                value
+                for row in rows
+                if (value := _safe_float(row.get("direction_correct"))) is not None
+            )
+        ),
+        "q10_q90_coverage": _round(_mean(interval_values)),
+        "interval_samples": len(interval_values),
+        "confidence_warning": warning,
+    }
+
+
+def _sort_models(names: Iterable[str]) -> list[str]:
+    priority = {ENSEMBLE_MODEL: 0, PERSISTENCE_MODEL: 1}
+    return sorted(set(names), key=lambda name: (priority.get(name, 2), name))
+
+
+def _window_rows(
+    rows: list[dict[str, Any]],
+    *,
+    now: datetime,
+    days: int | None,
+) -> list[dict[str, Any]]:
+    if days is None:
+        return rows
+    cutoff = now - timedelta(days=days)
+    return [
+        row
+        for row in rows
+        if row.get("origin_at") and _parse_timestamp(row["origin_at"]) >= cutoff
+    ]
+
+
+def _horizon_report(
+    rows: list[dict[str, Any]],
+    *,
+    horizon: int,
+    low_sample_threshold: int,
+) -> dict[str, Any]:
+    horizon_rows = [row for row in rows if int(row["horizon_hours"]) == horizon]
+    model_names = _sort_models(
+        [str(row["model_name"]) for row in horizon_rows]
+        + [ENSEMBLE_MODEL, PERSISTENCE_MODEL]
+    )
+    models = {
+        name: _metric_summary(
+            [row for row in horizon_rows if str(row["model_name"]) == name],
+            low_sample_threshold,
+        )
+        for name in model_names
+    }
+
+    regimes = sorted(
+        {
+            str(row.get("regime") or "unknown")
+            for row in horizon_rows
+            if row.get("regime") is not None
+        }
+        or {"unknown"}
+    )
+    by_regime: dict[str, Any] = {}
+    for regime in regimes:
+        regime_rows = [
+            row for row in horizon_rows if str(row.get("regime") or "unknown") == regime
+        ]
+        by_regime[regime] = {
+            name: _metric_summary(
+                [row for row in regime_rows if str(row["model_name"]) == name],
+                low_sample_threshold,
+            )
+            for name in model_names
+        }
+
+    persistence_missing = models[PERSISTENCE_MODEL]["samples"] == 0
+    return {
+        "models": models,
+        "by_regime": by_regime,
+        "persistence_baseline_missing": persistence_missing,
+    }
+
+
+def build_report(
+    rows: list[dict[str, Any]],
+    *,
+    now: datetime | None = None,
+    rolling_days: tuple[int, ...] = DEFAULT_ROLLING_DAYS,
+    low_sample_threshold: int = DEFAULT_LOW_SAMPLE_THRESHOLD,
+) -> dict[str, Any]:
+    """Build a JSON-serializable dashboard report from exported history rows."""
+    if low_sample_threshold < 1:
+        raise ValueError("low_sample_threshold must be >= 1")
+    if any(day < 1 for day in rolling_days):
+        raise ValueError("rolling_days must contain positive integers")
+
+    current_time = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    matured_rows = [row for row in rows if row.get("actual_target_price_usd") is not None]
+    horizons = sorted(
+        set(DEFAULT_HORIZONS)
+        | {
+            int(row["horizon_hours"])
+            for row in matured_rows
+            if row.get("horizon_hours") is not None
+        }
+    )
+
+    windows: dict[str, Any] = {}
+    window_specs: list[tuple[str, int | None]] = [("all", None)]
+    window_specs.extend((f"{days}d", days) for days in sorted(set(rolling_days)))
+
+    for label, days in window_specs:
+        selected = _window_rows(matured_rows, now=current_time, days=days)
+        windows[label] = {
+            "days": days,
+            "matured_rows": len(selected),
+            "horizons": {
+                f"{horizon}h": _horizon_report(
+                    selected,
+                    horizon=horizon,
+                    low_sample_threshold=low_sample_threshold,
+                )
+                for horizon in horizons
+            },
+        }
+
+    return {
+        "generated_at": current_time.isoformat(),
+        "baseline_model": PERSISTENCE_MODEL,
+        "ensemble_model": ENSEMBLE_MODEL,
+        "low_sample_threshold": low_sample_threshold,
+        "rolling_days": sorted(set(rolling_days)),
+        "matured_rows": len(matured_rows),
+        "horizons": [f"{horizon}h" for horizon in horizons],
+        "windows": windows,
+    }
+
+
+def _pct(value: Any, *, scale: float = 1.0) -> str:
+    number = _safe_float(value)
+    if number is None:
+        return "—"
+    return f"{number * scale:.2f}%"
+
+
+def _metric_table_rows(report: dict[str, Any], window: str) -> list[list[str]]:
+    rows: list[list[str]] = []
+    horizons = report["windows"][window]["horizons"]
+    for horizon in report["horizons"]:
+        models = horizons[horizon]["models"]
+        for model_name in _sort_models(models):
+            metrics = models[model_name]
+            rows.append(
+                [
+                    horizon,
+                    model_name,
+                    str(metrics["samples"]),
+                    _pct(metrics["mae_pct"]),
+                    _pct(metrics["mean_signed_error_pct"]),
+                    _pct(metrics["direction_accuracy"], scale=100.0),
+                    _pct(metrics["q10_q90_coverage"], scale=100.0),
+                    metrics["confidence_warning"] or "",
+                ]
+            )
+    return rows
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Forecast performance dashboard",
+        "",
+        f"Generated: `{report['generated_at']}`",
+        f"Matured forecast rows: **{report['matured_rows']}**",
+        f"Low-sample warning threshold: **{report['low_sample_threshold']}**",
+        "",
+        "Persistence is the required baseline in every horizon. Missing or low-sample "
+        "segments are explicitly flagged.",
+        "",
+    ]
+
+    for window in report["windows"]:
+        label = "All time" if window == "all" else f"Last {window}"
+        lines.extend(
+            [
+                f"## {label}",
+                "",
+                "| Horizon | Model | Samples | MAE | Bias | Direction | Q10–Q90 coverage | Warning |",
+                "| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
+            ]
+        )
+        for values in _metric_table_rows(report, window):
+            lines.append("| " + " | ".join(values) + " |")
+        lines.append("")
+
+        horizons = report["windows"][window]["horizons"]
+        lines.append("### By market regime")
+        lines.append("")
+        for horizon in report["horizons"]:
+            lines.append(f"#### {horizon}")
+            lines.append("")
+            lines.append(
+                "| Regime | Model | Samples | MAE | Bias | Direction | Q10–Q90 coverage | Warning |"
+            )
+            lines.append("| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |")
+            for regime, models in horizons[horizon]["by_regime"].items():
+                for model_name in _sort_models(models):
+                    metrics = models[model_name]
+                    lines.append(
+                        "| "
+                        + " | ".join(
+                            [
+                                regime,
+                                model_name,
+                                str(metrics["samples"]),
+                                _pct(metrics["mae_pct"]),
+                                _pct(metrics["mean_signed_error_pct"]),
+                                _pct(metrics["direction_accuracy"], scale=100.0),
+                                _pct(metrics["q10_q90_coverage"], scale=100.0),
+                                metrics["confidence_warning"] or "",
+                            ]
+                        )
+                        + " |"
+                    )
+            lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_html(report: dict[str, Any]) -> str:
+    sections: list[str] = []
+    for window in report["windows"]:
+        label = "All time" if window == "all" else f"Last {window}"
+        table_rows = []
+        for values in _metric_table_rows(report, window):
+            warning = values[-1]
+            row_class = ' class="warn"' if warning else ""
+            cells = "".join(f"<td>{html.escape(value)}</td>" for value in values)
+            table_rows.append(f"<tr{row_class}>{cells}</tr>")
+
+        regime_blocks: list[str] = []
+        horizons = report["windows"][window]["horizons"]
+        for horizon in report["horizons"]:
+            regime_rows = []
+            for regime, models in horizons[horizon]["by_regime"].items():
+                for model_name in _sort_models(models):
+                    metrics = models[model_name]
+                    values = [
+                        regime,
+                        model_name,
+                        str(metrics["samples"]),
+                        _pct(metrics["mae_pct"]),
+                        _pct(metrics["mean_signed_error_pct"]),
+                        _pct(metrics["direction_accuracy"], scale=100.0),
+                        _pct(metrics["q10_q90_coverage"], scale=100.0),
+                        metrics["confidence_warning"] or "",
+                    ]
+                    row_class = ' class="warn"' if values[-1] else ""
+                    cells = "".join(f"<td>{html.escape(value)}</td>" for value in values)
+                    regime_rows.append(f"<tr{row_class}>{cells}</tr>")
+            regime_blocks.append(
+                f"""
+                <details>
+                  <summary>{html.escape(horizon)} by regime</summary>
+                  <table>
+                    <thead><tr><th>Regime</th><th>Model</th><th>Samples</th><th>MAE</th>
+                    <th>Bias</th><th>Direction</th><th>Q10–Q90 coverage</th><th>Warning</th></tr></thead>
+                    <tbody>{''.join(regime_rows)}</tbody>
+                  </table>
+                </details>
+                """
+            )
+
+        sections.append(
+            f"""
+            <section>
+              <h2>{html.escape(label)}</h2>
+              <table>
+                <thead><tr><th>Horizon</th><th>Model</th><th>Samples</th><th>MAE</th>
+                <th>Bias</th><th>Direction</th><th>Q10–Q90 coverage</th><th>Warning</th></tr></thead>
+                <tbody>{''.join(table_rows)}</tbody>
+              </table>
+              {''.join(regime_blocks)}
+            </section>
+            """
+        )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>BTC forecast performance dashboard</title>
+<style>
+body {{ font-family: system-ui, sans-serif; margin: 2rem; line-height: 1.4; color: #222; }}
+table {{ border-collapse: collapse; width: 100%; margin: 1rem 0 2rem; }}
+th, td {{ border: 1px solid #ddd; padding: .45rem .6rem; text-align: right; }}
+th:first-child, td:first-child, th:nth-child(2), td:nth-child(2), th:last-child, td:last-child {{
+  text-align: left;
+}}
+th {{ background: #f5f5f5; }}
+.warn {{ background: #fff7d6; }}
+details {{ margin: .75rem 0; }}
+code {{ background: #f5f5f5; padding: .1rem .3rem; }}
+</style>
+</head>
+<body>
+<h1>BTC forecast performance dashboard</h1>
+<p>Generated <code>{html.escape(report['generated_at'])}</code>. Matured rows:
+<strong>{report['matured_rows']}</strong>. Low-sample threshold:
+<strong>{report['low_sample_threshold']}</strong>.</p>
+<p>Persistence is always shown as the baseline. Yellow rows indicate missing or low-sample segments.</p>
+{''.join(sections)}
+</body>
+</html>
+"""
+
+
+def generate_dashboard(
+    db_path: Path,
+    *,
+    json_path: Path,
+    markdown_path: Path,
+    html_path: Path,
+    rolling_days: tuple[int, ...] = DEFAULT_ROLLING_DAYS,
+    low_sample_threshold: int = DEFAULT_LOW_SAMPLE_THRESHOLD,
+) -> dict[str, Any]:
+    store = ForecastHistoryStore(db_path)
+    verification = store.verify()
+    if not verification.get("ok"):
+        raise RuntimeError(f"forecast history failed verification: {verification}")
+
+    report = build_report(
+        store.export_rows(),
+        rolling_days=rolling_days,
+        low_sample_threshold=low_sample_threshold,
+    )
+    report["database_verification"] = verification
+
+    for path in (json_path, markdown_path, html_path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    markdown_path.write_text(render_markdown(report), encoding="utf-8")
+    html_path.write_text(render_html(report), encoding="utf-8")
+    return report
+
+
+def _parse_rolling_days(value: str) -> tuple[int, ...]:
+    try:
+        days = tuple(sorted({int(item.strip()) for item in value.split(",") if item.strip()}))
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("rolling days must be comma-separated integers") from exc
+    if not days or any(day < 1 for day in days):
+        raise argparse.ArgumentTypeError("rolling days must contain positive integers")
+    return days
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate performance dashboard artifacts from durable forecast history"
+    )
+    parser.add_argument("--db", type=Path, default=DEFAULT_DB_PATH)
+    parser.add_argument("--json", type=Path, default=Path("performance_dashboard.json"))
+    parser.add_argument("--markdown", type=Path, default=Path("performance_dashboard.md"))
+    parser.add_argument("--html", type=Path, default=Path("performance_dashboard.html"))
+    parser.add_argument(
+        "--rolling-days",
+        type=_parse_rolling_days,
+        default=DEFAULT_ROLLING_DAYS,
+        help="Comma-separated rolling windows, default: 7,30,90",
+    )
+    parser.add_argument("--low-sample-threshold", type=int, default=DEFAULT_LOW_SAMPLE_THRESHOLD)
+    args = parser.parse_args()
+
+    report = generate_dashboard(
+        args.db,
+        json_path=args.json,
+        markdown_path=args.markdown,
+        html_path=args.html,
+        rolling_days=args.rolling_days,
+        low_sample_threshold=args.low_sample_threshold,
+    )
+    print(
+        json.dumps(
+            {
+                "generated_at": report["generated_at"],
+                "matured_rows": report["matured_rows"],
+                "horizons": report["horizons"],
+                "json": str(args.json),
+                "markdown": str(args.markdown),
+                "html": str(args.html),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/performance_dashboard.py
+++ b/performance_dashboard.py
@@ -104,9 +104,7 @@ def _window_rows(
         return rows
     cutoff = now - timedelta(days=days)
     return [
-        row
-        for row in rows
-        if row.get("origin_at") and _parse_timestamp(row["origin_at"]) >= cutoff
+        row for row in rows if row.get("origin_at") and _parse_timestamp(row["origin_at"]) >= cutoff
     ]
 
 
@@ -118,8 +116,7 @@ def _horizon_report(
 ) -> dict[str, Any]:
     horizon_rows = [row for row in rows if int(row["horizon_hours"]) == horizon]
     model_names = _sort_models(
-        [str(row["model_name"]) for row in horizon_rows]
-        + [ENSEMBLE_MODEL, PERSISTENCE_MODEL]
+        [str(row["model_name"]) for row in horizon_rows] + [ENSEMBLE_MODEL, PERSISTENCE_MODEL]
     )
     models = {
         name: _metric_summary(
@@ -139,9 +136,7 @@ def _horizon_report(
     )
     by_regime: dict[str, Any] = {}
     for regime in regimes:
-        regime_rows = [
-            row for row in horizon_rows if str(row.get("regime") or "unknown") == regime
-        ]
+        regime_rows = [row for row in horizon_rows if str(row.get("regime") or "unknown") == regime]
         by_regime[regime] = {
             name: _metric_summary(
                 [row for row in regime_rows if str(row["model_name"]) == name],
@@ -341,7 +336,7 @@ def render_html(report: dict[str, Any]) -> str:
                   <table>
                     <thead><tr><th>Regime</th><th>Model</th><th>Samples</th><th>MAE</th>
                     <th>Bias</th><th>Direction</th><th>Q10–Q90 coverage</th><th>Warning</th></tr></thead>
-                    <tbody>{''.join(regime_rows)}</tbody>
+                    <tbody>{"".join(regime_rows)}</tbody>
                   </table>
                 </details>
                 """
@@ -354,9 +349,9 @@ def render_html(report: dict[str, Any]) -> str:
               <table>
                 <thead><tr><th>Horizon</th><th>Model</th><th>Samples</th><th>MAE</th>
                 <th>Bias</th><th>Direction</th><th>Q10–Q90 coverage</th><th>Warning</th></tr></thead>
-                <tbody>{''.join(table_rows)}</tbody>
+                <tbody>{"".join(table_rows)}</tbody>
               </table>
-              {''.join(regime_blocks)}
+              {"".join(regime_blocks)}
             </section>
             """
         )
@@ -382,11 +377,11 @@ code {{ background: #f5f5f5; padding: .1rem .3rem; }}
 </head>
 <body>
 <h1>BTC forecast performance dashboard</h1>
-<p>Generated <code>{html.escape(report['generated_at'])}</code>. Matured rows:
-<strong>{report['matured_rows']}</strong>. Low-sample threshold:
-<strong>{report['low_sample_threshold']}</strong>.</p>
+<p>Generated <code>{html.escape(report["generated_at"])}</code>. Matured rows:
+<strong>{report["matured_rows"]}</strong>. Low-sample threshold:
+<strong>{report["low_sample_threshold"]}</strong>.</p>
 <p>Persistence is always shown as the baseline. Yellow rows indicate missing or low-sample segments.</p>
-{''.join(sections)}
+{"".join(sections)}
 </body>
 </html>
 """
@@ -403,7 +398,13 @@ def generate_dashboard(
 ) -> dict[str, Any]:
     store = ForecastHistoryStore(db_path)
     verification = store.verify()
-    if not verification.get("ok"):
+    verification_ok = (
+        verification.get("integrity") == "ok"
+        and int(verification.get("foreign_key_violations", 1)) == 0
+        and verification.get("schema_version") == verification.get("supported_schema_version")
+    )
+    verification = {**verification, "ok": verification_ok}
+    if not verification_ok:
         raise RuntimeError(f"forecast history failed verification: {verification}")
 
     report = build_report(

--- a/test_performance_dashboard.py
+++ b/test_performance_dashboard.py
@@ -1,0 +1,233 @@
+import json
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from history_store import ForecastHistoryStore
+from performance_dashboard import build_report, generate_dashboard, render_html, render_markdown
+
+
+NOW = datetime(2026, 9, 5, 22, 0, tzinfo=timezone.utc)
+
+
+def row(
+    *,
+    origin_at: str,
+    model: str,
+    horizon: int,
+    regime: str,
+    mae: float,
+    bias: float,
+    direction: int,
+    coverage: int | None,
+) -> dict[str, object]:
+    return {
+        "origin_at": origin_at,
+        "model_name": model,
+        "horizon_hours": horizon,
+        "regime": regime,
+        "actual_target_price_usd": 100.0,
+        "absolute_error_pct": mae,
+        "signed_error_pct": bias,
+        "direction_correct": direction,
+        "within_q10_q90": coverage,
+    }
+
+
+class PerformanceDashboardTests(unittest.TestCase):
+    def test_required_horizons_and_persistence_are_always_visible(self) -> None:
+        report = build_report(
+            [
+                row(
+                    origin_at="2026-09-05T20:00:00+00:00",
+                    model="ensemble",
+                    horizon=2,
+                    regime="range",
+                    mae=1.0,
+                    bias=0.2,
+                    direction=1,
+                    coverage=1,
+                )
+            ],
+            now=NOW,
+            low_sample_threshold=2,
+        )
+
+        self.assertEqual(report["horizons"], ["2h", "4h", "8h", "16h"])
+        for horizon in report["horizons"]:
+            models = report["windows"]["all"]["horizons"][horizon]["models"]
+            self.assertIn("ensemble", models)
+            self.assertIn("persistence", models)
+
+        two_hour = report["windows"]["all"]["horizons"]["2h"]
+        self.assertTrue(two_hour["persistence_baseline_missing"])
+        self.assertEqual(two_hour["models"]["persistence"]["confidence_warning"], "no_samples")
+
+    def test_metrics_are_computed_per_model(self) -> None:
+        rows = [
+            row(
+                origin_at="2026-09-05T18:00:00+00:00",
+                model="ensemble",
+                horizon=2,
+                regime="range",
+                mae=1.0,
+                bias=0.5,
+                direction=1,
+                coverage=1,
+            ),
+            row(
+                origin_at="2026-09-05T20:00:00+00:00",
+                model="ensemble",
+                horizon=2,
+                regime="range",
+                mae=3.0,
+                bias=-0.5,
+                direction=0,
+                coverage=0,
+            ),
+            row(
+                origin_at="2026-09-05T20:00:00+00:00",
+                model="persistence",
+                horizon=2,
+                regime="range",
+                mae=4.0,
+                bias=1.0,
+                direction=1,
+                coverage=None,
+            ),
+        ]
+        report = build_report(rows, now=NOW, low_sample_threshold=2)
+        ensemble = report["windows"]["all"]["horizons"]["2h"]["models"]["ensemble"]
+
+        self.assertEqual(ensemble["samples"], 2)
+        self.assertEqual(ensemble["mae_pct"], 2.0)
+        self.assertEqual(ensemble["mean_signed_error_pct"], 0.0)
+        self.assertEqual(ensemble["direction_accuracy"], 0.5)
+        self.assertEqual(ensemble["q10_q90_coverage"], 0.5)
+        self.assertEqual(ensemble["interval_samples"], 2)
+        self.assertIsNone(ensemble["confidence_warning"])
+
+    def test_rolling_windows_and_regimes_are_separate(self) -> None:
+        rows = [
+            row(
+                origin_at="2026-08-01T00:00:00+00:00",
+                model="ensemble",
+                horizon=4,
+                regime="trending",
+                mae=5.0,
+                bias=2.0,
+                direction=0,
+                coverage=0,
+            ),
+            row(
+                origin_at="2026-09-04T20:00:00+00:00",
+                model="ensemble",
+                horizon=4,
+                regime="range",
+                mae=1.0,
+                bias=0.1,
+                direction=1,
+                coverage=1,
+            ),
+            row(
+                origin_at="2026-09-04T20:00:00+00:00",
+                model="persistence",
+                horizon=4,
+                regime="range",
+                mae=2.0,
+                bias=-0.2,
+                direction=1,
+                coverage=None,
+            ),
+        ]
+        report = build_report(rows, now=NOW, rolling_days=(7, 30), low_sample_threshold=1)
+
+        self.assertEqual(report["windows"]["7d"]["matured_rows"], 2)
+        self.assertEqual(
+            report["windows"]["7d"]["horizons"]["4h"]["models"]["ensemble"]["mae_pct"],
+            1.0,
+        )
+        self.assertIn("range", report["windows"]["7d"]["horizons"]["4h"]["by_regime"])
+        self.assertNotIn(
+            "trending",
+            report["windows"]["7d"]["horizons"]["4h"]["by_regime"],
+        )
+
+    def test_renderers_surface_warnings_and_baseline(self) -> None:
+        report = build_report([], now=NOW, rolling_days=(7,), low_sample_threshold=20)
+        markdown = render_markdown(report)
+        html = render_html(report)
+
+        self.assertIn("Persistence", markdown)
+        self.assertIn("persistence", markdown)
+        self.assertIn("no_samples", markdown)
+        self.assertIn("persistence", html)
+        self.assertIn("no_samples", html)
+
+    def test_invalid_configuration_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            build_report([], now=NOW, low_sample_threshold=0)
+        with self.assertRaises(ValueError):
+            build_report([], now=NOW, rolling_days=(0,))
+
+    def test_generate_dashboard_reads_durable_history(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            db = root / "history.sqlite"
+            store = ForecastHistoryStore(db)
+            snapshot = {
+                "generated_at": "2026-09-05T18:00:00+00:00",
+                "latest_close_at": "2026-09-05T18:00:00+00:00",
+                "latest_close_usd": 100.0,
+                "source": "test",
+                "pair": "BTCUSD",
+                "regime": "range",
+                "market_features": {},
+                "predictions": {
+                    "2h": {
+                        "price_usd": 102.0,
+                        "change_pct": 2.0,
+                        "q10_usd": 99.0,
+                        "q50_usd": 102.0,
+                        "q90_usd": 104.0,
+                    }
+                },
+                "model_predictions": {
+                    "persistence": {"2h": {"price_usd": 100.0}},
+                    "timesfm_168": {"2h": {"price_usd": 103.0}},
+                },
+                "model_weights": {"2h": {"persistence": 0.2, "timesfm_168": 0.8}},
+            }
+            target = int(datetime(2026, 9, 5, 20, tzinfo=timezone.utc).timestamp())
+            store.ingest_snapshot(snapshot, {target: 101.0})
+
+            json_path = root / "dashboard.json"
+            markdown_path = root / "dashboard.md"
+            html_path = root / "dashboard.html"
+            report = generate_dashboard(
+                db,
+                json_path=json_path,
+                markdown_path=markdown_path,
+                html_path=html_path,
+                rolling_days=(7,),
+                low_sample_threshold=1,
+            )
+
+            self.assertEqual(
+                report["windows"]["all"]["horizons"]["2h"]["models"]["ensemble"]["samples"],
+                1,
+            )
+            self.assertEqual(
+                report["windows"]["all"]["horizons"]["2h"]["models"]["persistence"]["samples"],
+                1,
+            )
+            self.assertTrue(json_path.exists())
+            self.assertTrue(markdown_path.exists())
+            self.assertTrue(html_path.exists())
+            payload = json.loads(json_path.read_text(encoding="utf-8"))
+            self.assertTrue(payload["database_verification"]["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- generate a durable-history performance report without manual preprocessing
- show MAE, signed bias, direction accuracy, interval coverage and sample counts by 2h/4h/8h/16h horizon
- compare ensemble, every persisted individual model and persistence baseline
- segment all metrics by market regime and all-time/7d/30d/90d rolling windows
- flag missing and low-sample segments explicitly
- emit JSON, Markdown and standalone HTML outputs
- regenerate the dashboard automatically every day from the canonical forecast-history Release asset
- append the Markdown view to the Actions summary and retain dashboard artifacts for 90 days
- add unit/integration coverage and type checking

Closes #23