### PR TITLE
Add bounded forecast-history backup and recovery policy

### DIFF
--- a/.github/workflows/forecast.yml
+++ b/.github/workflows/forecast.yml
@@ -19,6 +19,9 @@ permissions:
 
 env:
   HISTORY_RELEASE_TAG: forecast-history-v1
+  HISTORY_BACKUP_KEEP: "7"
+  HISTORY_BACKUP_MAX_BYTES: "52428800"
+  HISTORY_BACKUP_MAX_TOTAL_BYTES: "262144000"
 
 concurrency:
   group: btc-timesfm-forecast
@@ -136,9 +139,18 @@ jobs:
             --format csv --output .state/forecast_history.csv
           gzip -c .state/forecast_history.sqlite > .state/forecast_history.sqlite.gz
           gzip -c .state/forecast_history.csv > .state/forecast_history.csv.gz
+
+          canonical_bytes="$(stat -c%s .state/forecast_history.sqlite.gz)"
+          if [ "$canonical_bytes" -gt "$HISTORY_BACKUP_MAX_BYTES" ]; then
+            echo "Compressed canonical history is ${canonical_bytes} bytes; limit is ${HISTORY_BACKUP_MAX_BYTES}." >&2
+            exit 1
+          fi
+
           if [ -f .state/forecast_history.previous.sqlite ]; then
-            gzip -c .state/forecast_history.previous.sqlite \
-              > .state/forecast_history.previous.sqlite.gz
+            python history_backup.py create \
+              --source .state/forecast_history.previous.sqlite \
+              --output .state/forecast_history.previous.sqlite.gz \
+              --max-bytes "$HISTORY_BACKUP_MAX_BYTES"
           fi
 
       - name: Publish durable forecast history
@@ -156,11 +168,54 @@ jobs:
           fi
 
           if [ -f .state/history_restored_from_release ]; then
-            # We only overwrite a release that was successfully restored in
-            # this same run. If restore failed transiently, this guard prevents
-            # a fresh empty database from clobbering an existing history.
+            # Preserve and verify a unique generation of the known-good database
+            # before replacing the canonical Release asset.
+            generation="$(date -u +%Y%m%dT%H%M%SZ)-${GITHUB_RUN_ID}"
+            backup_name="forecast_history.backup-${generation}.sqlite.gz"
+            versioned_backup=".state/${backup_name}"
+            cp .state/forecast_history.previous.sqlite.gz "$versioned_backup"
+
+            gh release upload "$HISTORY_RELEASE_TAG" "$versioned_backup" \
+              --repo "$GITHUB_REPOSITORY"
+
+            rm -rf .state/backup_verify
+            mkdir -p .state/backup_verify
+            gh release download "$HISTORY_RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "$backup_name" \
+              --dir .state/backup_verify
+            python history_backup.py verify \
+              --archive ".state/backup_verify/${backup_name}" \
+              --max-bytes "$HISTORY_BACKUP_MAX_BYTES" \
+              > .state/uploaded_backup_verification.json
+
+            # Only after the new rollback generation has been re-downloaded and
+            # verified may the current canonical assets be replaced.
             gh release upload "$HISTORY_RELEASE_TAG" "${assets[@]}" \
               --repo "$GITHUB_REPOSITORY" --clobber
+
+            gh api "repos/$GITHUB_REPOSITORY/releases/tags/$HISTORY_RELEASE_TAG" \
+              --jq '.assets | map({id: .id, name: .name, size: .size, created_at: .created_at})' \
+              > .state/release_assets.json
+            python history_backup.py retention-plan \
+              --assets-json .state/release_assets.json \
+              --keep "$HISTORY_BACKUP_KEEP" \
+              --max-total-bytes "$HISTORY_BACKUP_MAX_TOTAL_BYTES" \
+              > .state/backup_retention_plan.json
+
+            python - <<'PY' > .state/delete_backup_asset_ids.txt
+          import json
+
+          with open(".state/backup_retention_plan.json", encoding="utf-8") as handle:
+              plan = json.load(handle)
+          for asset in plan["delete"]:
+              print(asset["id"])
+          PY
+            while read -r asset_id; do
+              if [ -n "$asset_id" ]; then
+                gh api -X DELETE "repos/$GITHUB_REPOSITORY/releases/assets/$asset_id"
+              fi
+            done < .state/delete_backup_asset_ids.txt
           else
             gh release create "$HISTORY_RELEASE_TAG" "${assets[@]}" \
               --repo "$GITHUB_REPOSITORY" \
@@ -182,6 +237,20 @@ jobs:
           echo '```json' >> "$GITHUB_STEP_SUMMARY"
           python history_store.py --db .state/forecast_history.sqlite stats >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+          if [ -f .state/uploaded_backup_verification.json ]; then
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo '### Verified history backup' >> "$GITHUB_STEP_SUMMARY"
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            cat .state/uploaded_backup_verification.json >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ -f .state/backup_retention_plan.json ]; then
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo '### History backup retention' >> "$GITHUB_STEP_SUMMARY"
+            echo '```json' >> "$GITHUB_STEP_SUMMARY"
+            cat .state/backup_retention_plan.json >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo '' >> "$GITHUB_STEP_SUMMARY"
           echo '## X post' >> "$GITHUB_STEP_SUMMARY"
           cat tweet.txt >> "$GITHUB_STEP_SUMMARY"
@@ -237,5 +306,7 @@ jobs:
             market_data_source.json
             forecast_observability.json
             forecast_observability.jsonl
+            .state/uploaded_backup_verification.json
+            .state/backup_retention_plan.json
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,6 +90,7 @@ jobs:
           mypy --follow-imports=skip \
             experiment_manifest.py \
             history_audit.py \
+            history_backup.py \
             history_migrations.py \
             history_store.py \
             market_data_sources.py \

--- a/HISTORY_BACKUP.md
+++ b/HISTORY_BACKUP.md
@@ -1,0 +1,105 @@
+# Forecast-history retention, backup and recovery
+
+The durable SQLite forecast history is a critical research asset. Production keeps a canonical database plus bounded, verified rollback generations in the private GitHub Release tagged `forecast-history-v1`.
+
+## Release assets
+
+The release contains these stable assets:
+
+- `forecast_history.sqlite.gz` — current canonical database
+- `forecast_history.csv.gz` — current analysis export
+- `forecast_history.previous.sqlite.gz` — compatibility/quick-rollback alias for the database that was canonical before the latest successful publish
+
+It also contains bounded versioned generations named:
+
+```text
+forecast_history.backup-YYYYMMDDTHHMMSSZ-RUN_ID.sqlite.gz
+```
+
+A versioned backup is created from the previously restored, verified canonical database before the current canonical asset is replaced.
+
+## Retention policy
+
+Defaults are intentionally conservative and can be changed in `.github/workflows/forecast.yml`:
+
+- retain at most **7 versioned generations**
+- reject any compressed backup generation larger than **50 MiB**
+- retain at most **250 MiB** across versioned backup generations
+- always retain the newest verified versioned generation, even if it alone crosses the total-byte target
+- delete oldest generations only after a new generation has been uploaded and independently re-downloaded and verified
+
+The canonical database and CSV are fixed-name assets that are replaced in place, so they do not grow the Release asset count over time. `forecast_history.previous.sqlite.gz` is also a fixed-name alias.
+
+## Production publish sequence
+
+For an existing history Release, the forecast workflow follows this order:
+
+1. download and verify the canonical database
+2. preserve that known-good database as `forecast_history.previous.sqlite`
+3. run the forecast and update the new canonical database
+4. validate both the new canonical database and the previous database
+5. gzip the previous database as a versioned generation
+6. upload the versioned generation without clobbering an existing generation
+7. re-download the exact uploaded generation and verify its SQLite integrity, foreign keys and schema version
+8. replace the canonical, CSV and `previous` alias assets
+9. compute a retention plan and delete only versioned generations outside the count/byte limits
+
+If any step before canonical replacement fails, the existing canonical Release remains untouched. Old backups are never pruned before the new generation has been verified.
+
+The very first production run has no previous canonical database, so it creates only the canonical assets. Versioned backups start with the next successful publish.
+
+## Local backup verification
+
+```bash
+python history_backup.py verify \
+  --archive forecast_history.backup-20260905T220000Z-123.sqlite.gz
+```
+
+Verification decompresses to a temporary location and validates the contained SQLite database. It does not modify the working history database.
+
+## Restore procedure
+
+Download a selected generation from the private Release:
+
+```bash
+gh release download forecast-history-v1 \
+  --pattern 'forecast_history.backup-20260905T220000Z-123.sqlite.gz' \
+  --output forecast_history.backup.sqlite.gz
+```
+
+Restore atomically:
+
+```bash
+python history_backup.py restore \
+  --archive forecast_history.backup.sqlite.gz \
+  --output .state/forecast_history.sqlite
+```
+
+Then verify the restored database with the normal history tooling:
+
+```bash
+python history_store.py --db .state/forecast_history.sqlite verify
+```
+
+`restore` verifies the archive before replacement, restores through a temporary file, validates the restored SQLite database again, and only then atomically replaces the requested destination. A corrupt or incompatible backup cannot silently overwrite an existing destination.
+
+## Manual recovery of the Release canonical asset
+
+Do not overwrite the Release first. Restore and verify locally, keep a local copy of the current Release asset, then upload the verified restored database only as an explicit operator recovery action. Production's normal workflow will create the next versioned generation before future canonical replacements.
+
+## Retention-plan inspection
+
+The workflow obtains the Release asset inventory and feeds it to:
+
+```bash
+python history_backup.py retention-plan \
+  --assets-json release_assets.json \
+  --keep 7 \
+  --max-total-bytes 262144000
+```
+
+The JSON result has `keep` and `delete` arrays. Only assets matching the versioned backup naming convention are eligible for deletion. Canonical, CSV, and `previous` assets are ignored by the pruning logic.
+
+## Failure behavior
+
+Backup creation fails closed when the source database is invalid or the compressed generation exceeds its configured cap. Backup verification fails on unreadable gzip data, SQLite integrity failures, foreign-key violations, or unsupported schema versions. In all of these cases, production must not remove old generations or replace a known-good canonical database as part of the failed backup sequence.

--- a/history_backup.py
+++ b/history_backup.py
@@ -67,7 +67,10 @@ def create_archive(
     output.parent.mkdir(parents=True, exist_ok=True)
     temporary = output.with_name(f".{output.name}.{os.getpid()}.tmp")
     try:
-        with source.open("rb") as source_handle, gzip.open(temporary, "wb", compresslevel=9) as target:
+        with (
+            source.open("rb") as source_handle,
+            gzip.open(temporary, "wb", compresslevel=9) as target,
+        ):
             shutil.copyfileobj(source_handle, target, length=1024 * 1024)
         archive_bytes = temporary.stat().st_size
         if archive_bytes > max_generation_bytes:
@@ -226,7 +229,9 @@ def _write_json(data: Any) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Manage durable forecast-history backup generations")
+    parser = argparse.ArgumentParser(
+        description="Manage durable forecast-history backup generations"
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     create = subparsers.add_parser("create")
@@ -254,9 +259,7 @@ def main() -> None:
     elif args.command == "verify":
         _write_json(verify_archive(args.archive, max_generation_bytes=args.max_bytes))
     elif args.command == "restore":
-        _write_json(
-            restore_archive(args.archive, args.output, max_generation_bytes=args.max_bytes)
-        )
+        _write_json(restore_archive(args.archive, args.output, max_generation_bytes=args.max_bytes))
     elif args.command == "retention-plan":
         payload = json.loads(args.assets_json.read_text(encoding="utf-8"))
         if not isinstance(payload, list):

--- a/history_backup.py
+++ b/history_backup.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Create, verify, restore, and prune durable forecast-history backups."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from history_migrations import validate_database
+
+BACKUP_PREFIX = "forecast_history.backup-"
+BACKUP_SUFFIX = ".sqlite.gz"
+DEFAULT_KEEP_GENERATIONS = 7
+DEFAULT_MAX_GENERATION_BYTES = 50 * 1024 * 1024
+DEFAULT_MAX_TOTAL_BACKUP_BYTES = 250 * 1024 * 1024
+
+
+def _verification_ok(result: dict[str, Any]) -> bool:
+    return (
+        result.get("integrity") == "ok"
+        and int(result.get("foreign_key_violations", 1)) == 0
+        and result.get("schema_version") == result.get("supported_schema_version")
+    )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def backup_asset_name(generation: str) -> str:
+    """Return the versioned release-asset name for one backup generation."""
+    generation = generation.strip()
+    if not generation or any(not (char.isalnum() or char in "-_.") for char in generation):
+        raise ValueError("generation must contain only letters, digits, '-', '_' or '.'")
+    return f"{BACKUP_PREFIX}{generation}{BACKUP_SUFFIX}"
+
+
+def create_archive(
+    source_db: Path | str,
+    output_archive: Path | str,
+    *,
+    max_generation_bytes: int = DEFAULT_MAX_GENERATION_BYTES,
+) -> dict[str, Any]:
+    """Validate and gzip a database without modifying the source."""
+    source = Path(source_db)
+    output = Path(output_archive)
+    if max_generation_bytes < 1:
+        raise ValueError("max_generation_bytes must be positive")
+    if not source.is_file():
+        raise FileNotFoundError(source)
+
+    verification = validate_database(source)
+    if not _verification_ok(verification):
+        raise RuntimeError(f"source database failed verification: {verification}")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(f".{output.name}.{os.getpid()}.tmp")
+    try:
+        with source.open("rb") as source_handle, gzip.open(temporary, "wb", compresslevel=9) as target:
+            shutil.copyfileobj(source_handle, target, length=1024 * 1024)
+        archive_bytes = temporary.stat().st_size
+        if archive_bytes > max_generation_bytes:
+            raise RuntimeError(
+                f"compressed backup is {archive_bytes} bytes, exceeding "
+                f"the {max_generation_bytes}-byte generation limit"
+            )
+        os.replace(temporary, output)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+    return {
+        "archive": str(output),
+        "archive_bytes": output.stat().st_size,
+        "sha256": _sha256(output),
+        "database_verification": {**verification, "ok": True},
+    }
+
+
+def verify_archive(
+    archive_path: Path | str,
+    *,
+    max_generation_bytes: int = DEFAULT_MAX_GENERATION_BYTES,
+) -> dict[str, Any]:
+    """Decompress an archive to a temporary file and validate the contained DB."""
+    archive = Path(archive_path)
+    if max_generation_bytes < 1:
+        raise ValueError("max_generation_bytes must be positive")
+    if not archive.is_file():
+        raise FileNotFoundError(archive)
+
+    archive_bytes = archive.stat().st_size
+    if archive_bytes > max_generation_bytes:
+        raise RuntimeError(
+            f"compressed backup is {archive_bytes} bytes, exceeding "
+            f"the {max_generation_bytes}-byte generation limit"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="forecast-history-verify-") as directory:
+        restored = Path(directory) / "forecast_history.sqlite"
+        try:
+            with gzip.open(archive, "rb") as source, restored.open("wb") as target:
+                shutil.copyfileobj(source, target, length=1024 * 1024)
+        except (OSError, EOFError) as exc:
+            raise RuntimeError(f"backup archive cannot be decompressed: {archive}") from exc
+
+        verification = validate_database(restored)
+        if not _verification_ok(verification):
+            raise RuntimeError(f"backup database failed verification: {verification}")
+
+    return {
+        "archive": str(archive),
+        "archive_bytes": archive_bytes,
+        "sha256": _sha256(archive),
+        "database_verification": {**verification, "ok": True},
+    }
+
+
+def restore_archive(
+    archive_path: Path | str,
+    output_db: Path | str,
+    *,
+    max_generation_bytes: int = DEFAULT_MAX_GENERATION_BYTES,
+) -> dict[str, Any]:
+    """Atomically restore a verified archive to ``output_db``."""
+    archive = Path(archive_path)
+    output = Path(output_db)
+    archive_report = verify_archive(archive, max_generation_bytes=max_generation_bytes)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(f".{output.name}.{os.getpid()}.restore.tmp")
+    try:
+        try:
+            with gzip.open(archive, "rb") as source, temporary.open("wb") as target:
+                shutil.copyfileobj(source, target, length=1024 * 1024)
+        except (OSError, EOFError) as exc:
+            raise RuntimeError(f"backup archive cannot be decompressed: {archive}") from exc
+
+        verification = validate_database(temporary)
+        if not _verification_ok(verification):
+            raise RuntimeError(f"restored database failed verification: {verification}")
+        os.replace(temporary, output)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+    return {
+        **archive_report,
+        "restored_to": str(output),
+        "restored_bytes": output.stat().st_size,
+        "restored_database_verification": {**verification, "ok": True},
+    }
+
+
+def _is_backup_asset(asset: dict[str, Any]) -> bool:
+    name = str(asset.get("name") or "")
+    return name.startswith(BACKUP_PREFIX) and name.endswith(BACKUP_SUFFIX)
+
+
+def retention_plan(
+    assets: list[dict[str, Any]],
+    *,
+    keep_generations: int = DEFAULT_KEEP_GENERATIONS,
+    max_total_bytes: int = DEFAULT_MAX_TOTAL_BACKUP_BYTES,
+) -> dict[str, Any]:
+    """Choose versioned backup assets to keep/delete under bounded retention."""
+    if keep_generations < 1:
+        raise ValueError("keep_generations must be >= 1")
+    if max_total_bytes < 1:
+        raise ValueError("max_total_bytes must be positive")
+
+    backups = [dict(asset) for asset in assets if _is_backup_asset(asset)]
+    backups.sort(
+        key=lambda asset: (str(asset.get("created_at") or ""), str(asset.get("name") or "")),
+        reverse=True,
+    )
+
+    keep: list[dict[str, Any]] = []
+    delete: list[dict[str, Any]] = []
+    kept_bytes = 0
+
+    for index, asset in enumerate(backups):
+        try:
+            size = max(0, int(asset.get("size") or 0))
+        except (TypeError, ValueError):
+            size = 0
+
+        # Always retain the newest generation. This guarantees at least one
+        # known-good rollback point even if it alone crosses the byte budget.
+        if index == 0:
+            keep.append(asset)
+            kept_bytes += size
+            continue
+
+        within_count = len(keep) < keep_generations
+        within_bytes = kept_bytes + size <= max_total_bytes
+        if within_count and within_bytes:
+            keep.append(asset)
+            kept_bytes += size
+        else:
+            delete.append(asset)
+
+    return {
+        "policy": {
+            "keep_generations": keep_generations,
+            "max_total_bytes": max_total_bytes,
+        },
+        "backup_assets_seen": len(backups),
+        "kept_bytes": kept_bytes,
+        "keep": keep,
+        "delete": delete,
+    }
+
+
+def _write_json(data: Any) -> None:
+    print(json.dumps(data, indent=2, sort_keys=True))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage durable forecast-history backup generations")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create")
+    create.add_argument("--source", type=Path, required=True)
+    create.add_argument("--output", type=Path, required=True)
+    create.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_GENERATION_BYTES)
+
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--archive", type=Path, required=True)
+    verify.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_GENERATION_BYTES)
+
+    restore = subparsers.add_parser("restore")
+    restore.add_argument("--archive", type=Path, required=True)
+    restore.add_argument("--output", type=Path, required=True)
+    restore.add_argument("--max-bytes", type=int, default=DEFAULT_MAX_GENERATION_BYTES)
+
+    retention = subparsers.add_parser("retention-plan")
+    retention.add_argument("--assets-json", type=Path, required=True)
+    retention.add_argument("--keep", type=int, default=DEFAULT_KEEP_GENERATIONS)
+    retention.add_argument("--max-total-bytes", type=int, default=DEFAULT_MAX_TOTAL_BACKUP_BYTES)
+
+    args = parser.parse_args()
+    if args.command == "create":
+        _write_json(create_archive(args.source, args.output, max_generation_bytes=args.max_bytes))
+    elif args.command == "verify":
+        _write_json(verify_archive(args.archive, max_generation_bytes=args.max_bytes))
+    elif args.command == "restore":
+        _write_json(
+            restore_archive(args.archive, args.output, max_generation_bytes=args.max_bytes)
+        )
+    elif args.command == "retention-plan":
+        payload = json.loads(args.assets_json.read_text(encoding="utf-8"))
+        if not isinstance(payload, list):
+            raise ValueError("assets JSON must contain a list")
+        assets = [dict(item) for item in payload if isinstance(item, dict)]
+        _write_json(
+            retention_plan(
+                assets,
+                keep_generations=args.keep,
+                max_total_bytes=args.max_total_bytes,
+            )
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/test_history_backup.py
+++ b/test_history_backup.py
@@ -1,0 +1,208 @@
+import gzip
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from history_backup import (
+    backup_asset_name,
+    create_archive,
+    restore_archive,
+    retention_plan,
+    verify_archive,
+)
+from history_migrations import validate_database
+from history_store import ForecastHistoryStore
+
+
+class HistoryBackupTests(unittest.TestCase):
+    def _valid_database(self, root: Path) -> Path:
+        db = root / "forecast_history.sqlite"
+        ForecastHistoryStore(db)
+        verification = validate_database(db)
+        self.assertEqual(verification["integrity"], "ok")
+        return db
+
+    def test_backup_asset_name_is_versioned_and_rejects_unsafe_generations(self) -> None:
+        self.assertEqual(
+            backup_asset_name("20260905T220000Z-123"),
+            "forecast_history.backup-20260905T220000Z-123.sqlite.gz",
+        )
+        for invalid in ("", "with space", "../escape", "slash/name"):
+            with self.subTest(invalid=invalid), self.assertRaises(ValueError):
+                backup_asset_name(invalid)
+
+    def test_create_and_verify_archive_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            db = self._valid_database(root)
+            archive = root / "backup.sqlite.gz"
+
+            created = create_archive(db, archive)
+            verified = verify_archive(archive)
+
+            self.assertTrue(archive.exists())
+            self.assertGreater(created["archive_bytes"], 0)
+            self.assertEqual(created["sha256"], verified["sha256"])
+            self.assertTrue(created["database_verification"]["ok"])
+            self.assertTrue(verified["database_verification"]["ok"])
+
+    def test_restore_archive_recovers_valid_database(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            db = self._valid_database(root)
+            archive = root / "backup.sqlite.gz"
+            create_archive(db, archive)
+
+            restored = root / "restored.sqlite"
+            report = restore_archive(archive, restored)
+
+            self.assertTrue(restored.exists())
+            self.assertTrue(report["restored_database_verification"]["ok"])
+            self.assertEqual(validate_database(restored)["integrity"], "ok")
+
+    def test_corrupt_archive_does_not_overwrite_existing_destination(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive = root / "broken.sqlite.gz"
+            archive.write_bytes(b"not-gzip")
+            destination = root / "destination.sqlite"
+            destination.write_bytes(b"keep-me")
+
+            with self.assertRaises(RuntimeError):
+                restore_archive(archive, destination)
+
+            self.assertEqual(destination.read_bytes(), b"keep-me")
+
+    def test_invalid_database_inside_gzip_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive = root / "invalid.sqlite.gz"
+            with gzip.open(archive, "wb") as handle:
+                handle.write(b"not a sqlite database")
+
+            with self.assertRaises(Exception):
+                verify_archive(archive)
+
+    def test_generation_size_limit_is_enforced_without_leaving_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            db = self._valid_database(root)
+            archive = root / "too-large.sqlite.gz"
+
+            with self.assertRaises(RuntimeError):
+                create_archive(db, archive, max_generation_bytes=1)
+
+            self.assertFalse(archive.exists())
+
+    def test_retention_ignores_nonversioned_assets_and_keeps_newest_generations(self) -> None:
+        assets = [
+            {
+                "id": 1,
+                "name": "forecast_history.sqlite.gz",
+                "size": 10,
+                "created_at": "2026-09-05T00:00:00Z",
+            },
+            {
+                "id": 2,
+                "name": "forecast_history.previous.sqlite.gz",
+                "size": 10,
+                "created_at": "2026-09-05T00:00:00Z",
+            },
+            {
+                "id": 10,
+                "name": backup_asset_name("001"),
+                "size": 10,
+                "created_at": "2026-09-01T00:00:00Z",
+            },
+            {
+                "id": 11,
+                "name": backup_asset_name("002"),
+                "size": 10,
+                "created_at": "2026-09-02T00:00:00Z",
+            },
+            {
+                "id": 12,
+                "name": backup_asset_name("003"),
+                "size": 10,
+                "created_at": "2026-09-03T00:00:00Z",
+            },
+        ]
+
+        plan = retention_plan(assets, keep_generations=2, max_total_bytes=100)
+
+        self.assertEqual(plan["backup_assets_seen"], 3)
+        self.assertEqual([item["id"] for item in plan["keep"]], [12, 11])
+        self.assertEqual([item["id"] for item in plan["delete"]], [10])
+
+    def test_retention_respects_total_byte_budget(self) -> None:
+        assets = [
+            {
+                "id": 1,
+                "name": backup_asset_name("new"),
+                "size": 80,
+                "created_at": "2026-09-03T00:00:00Z",
+            },
+            {
+                "id": 2,
+                "name": backup_asset_name("middle"),
+                "size": 30,
+                "created_at": "2026-09-02T00:00:00Z",
+            },
+            {
+                "id": 3,
+                "name": backup_asset_name("old"),
+                "size": 10,
+                "created_at": "2026-09-01T00:00:00Z",
+            },
+        ]
+
+        plan = retention_plan(assets, keep_generations=7, max_total_bytes=100)
+
+        self.assertEqual([item["id"] for item in plan["keep"]], [1, 3])
+        self.assertEqual([item["id"] for item in plan["delete"]], [2])
+        self.assertEqual(plan["kept_bytes"], 90)
+
+    def test_retention_always_keeps_newest_generation(self) -> None:
+        assets = [
+            {
+                "id": 1,
+                "name": backup_asset_name("new"),
+                "size": 200,
+                "created_at": "2026-09-03T00:00:00Z",
+            },
+            {
+                "id": 2,
+                "name": backup_asset_name("old"),
+                "size": 1,
+                "created_at": "2026-09-02T00:00:00Z",
+            },
+        ]
+
+        plan = retention_plan(assets, keep_generations=7, max_total_bytes=100)
+        self.assertEqual([item["id"] for item in plan["keep"]], [1])
+        self.assertEqual([item["id"] for item in plan["delete"]], [2])
+
+    def test_retention_rejects_invalid_policy(self) -> None:
+        with self.assertRaises(ValueError):
+            retention_plan([], keep_generations=0)
+        with self.assertRaises(ValueError):
+            retention_plan([], max_total_bytes=0)
+
+    def test_assets_json_shape_is_serializable_for_workflow(self) -> None:
+        plan = retention_plan(
+            [
+                {
+                    "id": 42,
+                    "name": backup_asset_name("run-42"),
+                    "size": 123,
+                    "created_at": "2026-09-05T22:00:00Z",
+                }
+            ]
+        )
+        encoded = json.dumps(plan, sort_keys=True)
+        self.assertIn('"id": 42', encoded)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep unique, versioned generations of the previously verified canonical forecast-history database
- re-download and verify each newly uploaded backup before replacing the canonical Release asset
- retain at most 7 versioned generations and 250 MiB total by default
- enforce a 50 MiB compressed per-generation/canonical safety limit
- preserve the fixed `forecast_history.previous.sqlite.gz` compatibility alias
- prune only versioned backup assets and only after a new rollback generation is verified
- add atomic local restore tooling that cannot clobber a destination with a corrupt backup
- document operator backup verification, restore and retention procedures
- add unit tests for archive validation, restore safety, size bounds and retention planning
- add the backup module to the type-check gate

Closes #24