### PR TITLE
Harden X posting with idempotency and session-health checks

### DIFF
--- a/.github/workflows/forecast.yml
+++ b/.github/workflows/forecast.yml
@@ -74,6 +74,10 @@ jobs:
               --dir .state
             gzip -df .state/forecast_history.sqlite.gz
             cp .state/forecast_history.sqlite .state/forecast_history.previous.sqlite
+            gh release download "$HISTORY_RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern 'x_post_registry.json' \
+              --dir .state >/dev/null 2>&1 || true
             touch .state/history_restored_from_release
             echo "Restored durable history from release $HISTORY_RELEASE_TAG"
           else
@@ -134,6 +138,13 @@ jobs:
         if: steps.due.outputs.run_forecast == 'true'
         run: python format_tweet.py
 
+      - name: Preflight and reserve X publication
+        id: x_prepare
+        if: steps.due.outputs.run_forecast == 'true' && (github.event_name == 'schedule' || inputs.post_to_x)
+        env:
+          X_COOKIES_JSON: ${{ secrets.X_COOKIES_JSON }}
+        run: python post_to_x.py prepare
+
       - name: Verify and export durable history
         if: steps.due.outputs.run_forecast == 'true'
         run: |
@@ -169,6 +180,9 @@ jobs:
           )
           if [ -f .state/forecast_history.previous.sqlite.gz ]; then
             assets+=(.state/forecast_history.previous.sqlite.gz)
+          fi
+          if [ -f .state/x_post_registry.json ]; then
+            assets+=(.state/x_post_registry.json)
           fi
 
           if [ -f .state/history_restored_from_release ]; then
@@ -267,14 +281,23 @@ jobs:
           key: btc-forecast-state-${{ github.run_id }}
 
       - name: Post forecast to X with Twikit
-        if: steps.due.outputs.run_forecast == 'true' && (github.event_name == 'schedule' || inputs.post_to_x)
+        if: steps.due.outputs.run_forecast == 'true' && (github.event_name == 'schedule' || inputs.post_to_x) && steps.x_prepare.outputs.publish == 'true'
         env:
           X_COOKIES_JSON: ${{ secrets.X_COOKIES_JSON }}
         run: |
           python observability.py run-stage \
             --stage x_post \
             --success-counter successful_posts \
-            -- python post_to_x.py
+            -- python post_to_x.py publish
+
+      - name: Persist X publication metadata
+        if: always() && steps.due.outputs.run_forecast == 'true' && (github.event_name == 'schedule' || inputs.post_to_x) && steps.x_prepare.outputs.publish == 'true' && hashFiles('.state/x_post_registry.json') != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release upload "$HISTORY_RELEASE_TAG" .state/x_post_registry.json \
+            --repo "$GITHUB_REPOSITORY" --clobber
 
       - name: Add X posting status to job summary
         if: always() && steps.due.outputs.run_forecast == 'true' && hashFiles('x_post_status.json') != ''
@@ -312,6 +335,8 @@ jobs:
             drift_summary.md
             forecast_observability.json
             forecast_observability.jsonl
+            .state/x_post_registry.json
+            .state/x_post_prepared.json
             .state/uploaded_backup_verification.json
             .state/backup_retention_plan.json
           if-no-files-found: warn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,5 +98,7 @@ jobs:
             market_data_validation.py \
             observability.py \
             performance_dashboard.py \
+            post_to_x.py \
             schedule_guard.py \
-            statistical_significance.py
+            statistical_significance.py \
+            x_post_registry.py

--- a/X_POSTING.md
+++ b/X_POSTING.md
@@ -1,0 +1,53 @@
+# X publication safety
+
+Production X publishing uses Twikit with a browser-session cookie secret, but posting is now guarded by a durable idempotency registry and an authenticated session preflight.
+
+## Idempotency key
+
+Each publication gets a deterministic key derived from:
+
+- the forecast `latest_close_at` origin timestamp; and
+- the exact final text in `tweet.txt`.
+
+The SHA-256 key is stable across retries. Re-running the same forecast with the same text therefore resolves to the same registry record.
+
+The registry is stored as `.state/x_post_registry.json` and uploaded to the same machine-managed GitHub Release used for forecast history. Records include the forecast origin, content digest, experiment/configuration IDs, GitHub Actions run ID, attempt count, provider, status and final X post ID when available.
+
+## Two-phase publication
+
+Scheduled or explicitly requested manual publication follows this order:
+
+1. load and validate `X_COOKIES_JSON`;
+2. call an authenticated, read-only Twikit endpoint as a session preflight;
+3. reserve the deterministic idempotency key;
+4. persist the reservation to the durable Release before any write to X;
+5. call `create_tweet` only when the current run created a publishable reservation;
+6. record the returned post ID and persist the updated registry again.
+
+This intentionally prefers a missed post over a duplicate. If a previous run left a reservation in an uncertain state, later runs do not blindly retry it.
+
+## Failure classes
+
+Publishing distinguishes these classes:
+
+- `authentication` — expired/invalid cookies, login/challenge failures or 401/403-style responses;
+- `rate_limit` — 429/rate-limit responses;
+- `response_parsing` — Twikit/X response-shape failures, including missing post IDs;
+- `network` — transport, DNS, connection and timeout failures;
+- `provider_error` — other Twikit/X failures.
+
+Authentication and rate-limit failures from the actual create call are considered safe to retry because X rejected the request. Response-parsing, network and unknown provider failures are treated as ambiguous because the request may have reached X; their registry entry is locked against automatic replay.
+
+A session-preflight failure happens before a reservation is created, so fixing the session secret allows a later run to try normally.
+
+## Statuses
+
+`x_post_status.json` reports `prepared`, `posted`, `duplicate_skipped`, `duplicate_locked`, `preflight_failed` or `failed`. It is included in the Actions summary/artifact.
+
+The durable registry uses `reserved`, `posted`, `failed` and `ambiguous` states. A `posted` record contains the X `post_id` plus experiment and workflow-run metadata.
+
+## Operational recovery
+
+If a registry entry is `ambiguous`, confirm manually whether the post exists on X before changing the registry. Automatic retry is deliberately disabled for this state.
+
+If the session preflight reports `authentication`, refresh the `X_COOKIES_JSON` secret from an authenticated browser session and rerun. Do not paste those cookie values into issues, logs or chat output.

--- a/post_to_x.py
+++ b/post_to_x.py
@@ -1,26 +1,39 @@
 #!/usr/bin/env python3
-"""Post the generated forecast text to X using a Twikit web session."""
+"""Safely publish a generated forecast to X through a Twikit web session."""
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
 import os
 from pathlib import Path
+from typing import Any
 
 from twikit import Client
 
 from twikit_compat import apply_twikit_compat
+from x_post_registry import DEFAULT_REGISTRY_PATH, XPostRegistry, idempotency_key
 
 
 TWEET_PATH = Path("tweet.txt")
+FORECAST_PATH = Path("forecast.json")
 STATUS_PATH = Path("x_post_status.json")
+PREPARED_PATH = Path(".state/x_post_prepared.json")
+REGISTRY_PATH = DEFAULT_REGISTRY_PATH
 COOKIES_ENV = "X_COOKIES_JSON"
 
 
 def write_status(status: str, **extra: object) -> None:
     payload = {"status": status, **extra}
-    STATUS_PATH.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    STATUS_PATH.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _set_output(name: str, value: str) -> None:
+    output = os.getenv("GITHUB_OUTPUT")
+    if output:
+        with Path(output).open("a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
 
 
 def load_cookies() -> dict[str, str]:
@@ -45,48 +58,227 @@ def load_cookies() -> dict[str, str]:
     return {str(key): str(value) for key, value in cookies.items()}
 
 
-async def post() -> None:
+def load_post_context() -> dict[str, Any]:
     if not TWEET_PATH.exists():
         raise RuntimeError(f"{TWEET_PATH} does not exist; run btc_forecast.py first")
-
     text = TWEET_PATH.read_text(encoding="utf-8").strip()
     if not text:
         raise RuntimeError(f"{TWEET_PATH} is empty")
     if len(text) > 280:
         raise RuntimeError(f"Refusing to post {len(text)} characters to X")
 
+    if not FORECAST_PATH.exists():
+        raise RuntimeError(f"{FORECAST_PATH} does not exist; forecast metadata is required")
+    forecast = json.loads(FORECAST_PATH.read_text(encoding="utf-8"))
+    if not isinstance(forecast, dict):
+        raise RuntimeError(f"{FORECAST_PATH} must contain a JSON object")
+    origin_at = forecast.get("latest_close_at")
+    if not isinstance(origin_at, str) or not origin_at:
+        raise RuntimeError("forecast.json is missing latest_close_at")
+    manifest = forecast.get("experiment_manifest")
+    if not isinstance(manifest, dict):
+        manifest = {}
+
+    return {
+        "text": text,
+        "origin_at": origin_at,
+        "idempotency_key": idempotency_key(origin_at, text),
+        "experiment_run_id": manifest.get("run_id"),
+        "configuration_id": manifest.get("configuration_id"),
+        "github_run_id": os.getenv("GITHUB_RUN_ID"),
+    }
+
+
+def classify_twikit_error(exc: BaseException) -> str:
+    type_name = type(exc).__name__.lower()
+    message = str(exc).lower()
+    combined = f"{type_name} {message}"
+    if any(token in combined for token in ("401", "403", "unauthorized", "forbidden", "auth", "login", "cookie", "challenge")):
+        return "authentication"
+    if any(token in combined for token in ("429", "rate limit", "ratelimit", "too many requests")):
+        return "rate_limit"
+    if any(token in combined for token in ("json", "parse", "keyerror", "couldn't get", "could not get", "unexpected response")):
+        return "response_parsing"
+    if any(token in combined for token in ("timeout", "connection", "network", "transport", "dns")):
+        return "network"
+    return "provider_error"
+
+
+def _client() -> Client:
     apply_twikit_compat()
     client = Client(language="en-US")
     client.set_cookies(load_cookies(), clear_cookies=True)
+    return client
 
+
+async def session_preflight(client: Client) -> None:
+    """Touch an authenticated, read-only endpoint before any publication attempt."""
+    await client.get_bookmarks(count=1)
+
+
+async def prepare_post() -> bool:
+    """Validate the X session and persist a durable reservation before posting."""
     try:
-        tweet = await client.create_tweet(text=text)
+        context = load_post_context()
+        client = _client()
+        await session_preflight(client)
     except Exception as exc:
+        failure_class = classify_twikit_error(exc)
         write_status(
-            "failed",
+            "preflight_failed",
             provider="twikit",
+            failure_class=failure_class,
             error_type=type(exc).__name__,
             error=str(exc),
         )
-        print(f"::error::Twikit failed to post to X: {type(exc).__name__}: {exc}")
+        _set_output("publish", "false")
+        _set_output("reason", failure_class)
+        print(f"::warning::X session preflight failed ({failure_class}): {type(exc).__name__}: {exc}")
+        return False
+
+    registry = XPostRegistry(REGISTRY_PATH)
+    reservation = registry.reserve(
+        key=context["idempotency_key"],
+        origin_at=context["origin_at"],
+        text=context["text"],
+        experiment_run_id=context["experiment_run_id"],
+        configuration_id=context["configuration_id"],
+        github_run_id=context["github_run_id"],
+    )
+    record = reservation["record"]
+    action = str(reservation["action"])
+    if action != "publish":
+        status = "duplicate_skipped" if action == "duplicate" else "duplicate_locked"
+        write_status(
+            status,
+            provider="twikit",
+            idempotency_key=context["idempotency_key"],
+            origin_at=context["origin_at"],
+            existing_status=record.get("status"),
+            post_id=record.get("post_id"),
+        )
+        _set_output("publish", "false")
+        _set_output("reason", status)
+        print(f"Skipping X publication: idempotency registry status is {record.get('status')!r}.")
+        return False
+
+    PREPARED_PATH.parent.mkdir(parents=True, exist_ok=True)
+    PREPARED_PATH.write_text(
+        json.dumps(
+            {
+                "idempotency_key": context["idempotency_key"],
+                "origin_at": context["origin_at"],
+                "github_run_id": context["github_run_id"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    write_status(
+        "prepared",
+        provider="twikit",
+        idempotency_key=context["idempotency_key"],
+        origin_at=context["origin_at"],
+        retry=bool(reservation.get("retry")),
+    )
+    _set_output("publish", "true")
+    _set_output("reason", "prepared")
+    return True
+
+
+async def publish_post() -> None:
+    """Publish only a reservation created by this workflow run."""
+    context = load_post_context()
+    if not PREPARED_PATH.exists():
+        raise RuntimeError("X post was not prepared; refusing an unreserved publication attempt")
+    prepared = json.loads(PREPARED_PATH.read_text(encoding="utf-8"))
+    if not isinstance(prepared, dict) or prepared.get("idempotency_key") != context["idempotency_key"]:
+        raise RuntimeError("Prepared X post does not match the current forecast/content")
+    prepared_run = prepared.get("github_run_id")
+    if prepared_run and context["github_run_id"] and prepared_run != context["github_run_id"]:
+        raise RuntimeError("Prepared X post belongs to a different GitHub Actions run")
+
+    registry = XPostRegistry(REGISTRY_PATH)
+    existing = registry.get(context["idempotency_key"])
+    if existing is None or existing.get("status") != "reserved":
+        raise RuntimeError("X post reservation is no longer publishable")
+
+    client = _client()
+    try:
+        tweet = await client.create_tweet(text=context["text"])
+    except Exception as exc:
+        failure_class = classify_twikit_error(exc)
+        ambiguous = failure_class not in {"authentication", "rate_limit"}
+        registry.mark_failed(
+            context["idempotency_key"],
+            failure_class=failure_class,
+            error_type=type(exc).__name__,
+            error_message=str(exc),
+            ambiguous=ambiguous,
+        )
+        write_status(
+            "failed",
+            provider="twikit",
+            idempotency_key=context["idempotency_key"],
+            failure_class=failure_class,
+            ambiguous=ambiguous,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+        print(f"::error::Twikit failed to post to X ({failure_class}): {type(exc).__name__}: {exc}")
         raise
 
     tweet_id = getattr(tweet, "id", None)
     if not tweet_id:
+        registry.mark_failed(
+            context["idempotency_key"],
+            failure_class="response_parsing",
+            error_type="MissingPostId",
+            error_message="Twikit returned no post ID",
+            ambiguous=True,
+        )
         write_status(
             "failed",
             provider="twikit",
+            idempotency_key=context["idempotency_key"],
+            failure_class="response_parsing",
+            ambiguous=True,
             error="Twikit returned no post ID",
         )
         raise RuntimeError("Twikit returned no post ID")
 
-    write_status("posted", provider="twikit", post_id=str(tweet_id))
+    record = registry.mark_posted(context["idempotency_key"], str(tweet_id))
+    write_status(
+        "posted",
+        provider="twikit",
+        idempotency_key=context["idempotency_key"],
+        origin_at=context["origin_at"],
+        post_id=str(tweet_id),
+        experiment_run_id=record.get("experiment_run_id"),
+        github_run_id=record.get("github_run_id"),
+    )
     print(f"Posted forecast to X through Twikit. Post ID: {tweet_id}")
 
 
+async def post() -> None:
+    """Compatibility helper for local/manual callers: prepare then publish."""
+    if await prepare_post():
+        await publish_post()
+
+
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Safely publish the generated forecast to X")
+    parser.add_argument("command", nargs="?", choices=("prepare", "publish"), default="publish")
+    args = parser.parse_args()
+
+    if args.command == "prepare":
+        asyncio.run(prepare_post())
+        return
+
     try:
-        asyncio.run(post())
+        asyncio.run(publish_post())
     except Exception:
         if not STATUS_PATH.exists():
             write_status("failed", provider="twikit", error="Posting setup failed")

--- a/post_to_x.py
+++ b/post_to_x.py
@@ -93,11 +93,33 @@ def classify_twikit_error(exc: BaseException) -> str:
     type_name = type(exc).__name__.lower()
     message = str(exc).lower()
     combined = f"{type_name} {message}"
-    if any(token in combined for token in ("401", "403", "unauthorized", "forbidden", "auth", "login", "cookie", "challenge")):
+    if any(
+        token in combined
+        for token in (
+            "401",
+            "403",
+            "unauthorized",
+            "forbidden",
+            "auth",
+            "login",
+            "cookie",
+            "challenge",
+        )
+    ):
         return "authentication"
     if any(token in combined for token in ("429", "rate limit", "ratelimit", "too many requests")):
         return "rate_limit"
-    if any(token in combined for token in ("json", "parse", "keyerror", "couldn't get", "could not get", "unexpected response")):
+    if any(
+        token in combined
+        for token in (
+            "json",
+            "parse",
+            "keyerror",
+            "couldn't get",
+            "could not get",
+            "unexpected response",
+        )
+    ):
         return "response_parsing"
     if any(token in combined for token in ("timeout", "connection", "network", "transport", "dns")):
         return "network"
@@ -133,7 +155,9 @@ async def prepare_post() -> bool:
         )
         _set_output("publish", "false")
         _set_output("reason", failure_class)
-        print(f"::warning::X session preflight failed ({failure_class}): {type(exc).__name__}: {exc}")
+        print(
+            f"::warning::X session preflight failed ({failure_class}): {type(exc).__name__}: {exc}"
+        )
         return False
 
     registry = XPostRegistry(REGISTRY_PATH)
@@ -194,7 +218,10 @@ async def publish_post() -> None:
     if not PREPARED_PATH.exists():
         raise RuntimeError("X post was not prepared; refusing an unreserved publication attempt")
     prepared = json.loads(PREPARED_PATH.read_text(encoding="utf-8"))
-    if not isinstance(prepared, dict) or prepared.get("idempotency_key") != context["idempotency_key"]:
+    if (
+        not isinstance(prepared, dict)
+        or prepared.get("idempotency_key") != context["idempotency_key"]
+    ):
         raise RuntimeError("Prepared X post does not match the current forecast/content")
     prepared_run = prepared.get("github_run_id")
     if prepared_run and context["github_run_id"] and prepared_run != context["github_run_id"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ source = [
     "format_tweet",
     "post_to_x",
     "twikit_compat",
+    "x_post_registry",
 ]
 
 [tool.coverage.report]

--- a/test_post_to_x.py
+++ b/test_post_to_x.py
@@ -13,10 +13,14 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import post_to_x
+from x_post_registry import XPostRegistry
 
 
 class FakeClient:
     instance = None
+    preflight_error: Exception | None = None
+    publish_error: Exception | None = None
+    create_calls = 0
 
     def __init__(self, language: str) -> None:
         self.language = language
@@ -28,12 +32,26 @@ class FakeClient:
         self.cookies = cookies
         self.clear_cookies = clear_cookies
 
+    async def get_bookmarks(self, count: int = 1):
+        if self.preflight_error is not None:
+            raise self.preflight_error
+        return []
+
     async def create_tweet(self, *, text: str):
+        FakeClient.create_calls += 1
         self.text = text
+        if self.publish_error is not None:
+            raise self.publish_error
         return SimpleNamespace(id="123456")
 
 
 class PostToXTests(unittest.TestCase):
+    def setUp(self) -> None:
+        FakeClient.instance = None
+        FakeClient.preflight_error = None
+        FakeClient.publish_error = None
+        FakeClient.create_calls = 0
+
     def test_load_cookies_requires_environment_variable(self) -> None:
         with patch.dict(os.environ, {}, clear=True):
             with self.assertRaisesRegex(RuntimeError, "is not set"):
@@ -60,42 +78,137 @@ class PostToXTests(unittest.TestCase):
                 {"auth_token": "abc", "ct0": "def", "extra": "123"},
             )
 
-    def test_post_refuses_missing_empty_and_oversize_tweet(self) -> None:
+    def _paths(self, tmp: str) -> tuple[Path, Path, Path, Path, Path]:
+        root = Path(tmp)
+        return (
+            root / "tweet.txt",
+            root / "forecast.json",
+            root / "status.json",
+            root / "prepared.json",
+            root / "registry.json",
+        )
+
+    def _write_context(self, tweet: Path, forecast: Path, text: str = "hello BTC") -> None:
+        tweet.write_text(text, encoding="utf-8")
+        forecast.write_text(
+            json.dumps(
+                {
+                    "latest_close_at": "2026-09-05T20:00:00+00:00",
+                    "experiment_manifest": {
+                        "run_id": "exp-1",
+                        "configuration_id": "cfg-1",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_context_refuses_missing_empty_and_oversize_tweet(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "tweet.txt"
-            with patch.object(post_to_x, "TWEET_PATH", path):
-                with self.assertRaisesRegex(RuntimeError, "does not exist"):
-                    asyncio.run(post_to_x.post())
-
-                path.write_text("\n", encoding="utf-8")
-                with self.assertRaisesRegex(RuntimeError, "is empty"):
-                    asyncio.run(post_to_x.post())
-
-                path.write_text("x" * 281, encoding="utf-8")
-                with self.assertRaisesRegex(RuntimeError, "Refusing to post 281"):
-                    asyncio.run(post_to_x.post())
-
-    def test_successful_post_writes_status_without_network(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            tweet_path = Path(tmp) / "tweet.txt"
-            status_path = Path(tmp) / "status.json"
-            tweet_path.write_text("hello BTC", encoding="utf-8")
-            cookies = json.dumps({"auth_token": "abc", "ct0": "def"})
-
+            tweet, forecast, status, prepared, registry = self._paths(tmp)
+            forecast.write_text(
+                json.dumps({"latest_close_at": "2026-09-05T20:00:00+00:00"}),
+                encoding="utf-8",
+            )
             with (
-                patch.object(post_to_x, "TWEET_PATH", tweet_path),
-                patch.object(post_to_x, "STATUS_PATH", status_path),
+                patch.object(post_to_x, "TWEET_PATH", tweet),
+                patch.object(post_to_x, "FORECAST_PATH", forecast),
+                patch.object(post_to_x, "STATUS_PATH", status),
+                patch.object(post_to_x, "PREPARED_PATH", prepared),
+                patch.object(post_to_x, "REGISTRY_PATH", registry),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "does not exist"):
+                    post_to_x.load_post_context()
+                tweet.write_text("\n", encoding="utf-8")
+                with self.assertRaisesRegex(RuntimeError, "is empty"):
+                    post_to_x.load_post_context()
+                tweet.write_text("x" * 281, encoding="utf-8")
+                with self.assertRaisesRegex(RuntimeError, "Refusing to post 281"):
+                    post_to_x.load_post_context()
+
+    def test_expired_session_fails_preflight_before_publication(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tweet, forecast, status, prepared, registry = self._paths(tmp)
+            self._write_context(tweet, forecast)
+            FakeClient.preflight_error = RuntimeError("401 Unauthorized: login required")
+            cookies = json.dumps({"auth_token": "abc", "ct0": "def"})
+            with (
+                patch.object(post_to_x, "TWEET_PATH", tweet),
+                patch.object(post_to_x, "FORECAST_PATH", forecast),
+                patch.object(post_to_x, "STATUS_PATH", status),
+                patch.object(post_to_x, "PREPARED_PATH", prepared),
+                patch.object(post_to_x, "REGISTRY_PATH", registry),
                 patch.object(post_to_x, "Client", FakeClient),
                 patch.object(post_to_x, "apply_twikit_compat", lambda: None),
                 patch.dict(os.environ, {post_to_x.COOKIES_ENV: cookies}, clear=True),
             ):
-                asyncio.run(post_to_x.post())
+                self.assertFalse(asyncio.run(post_to_x.prepare_post()))
 
-            status = json.loads(status_path.read_text(encoding="utf-8"))
-            self.assertEqual(status["status"], "posted")
-            self.assertEqual(status["post_id"], "123456")
-            self.assertEqual(FakeClient.instance.text, "hello BTC")
-            self.assertTrue(FakeClient.instance.clear_cookies)
+            result = json.loads(status.read_text(encoding="utf-8"))
+            self.assertEqual(result["status"], "preflight_failed")
+            self.assertEqual(result["failure_class"], "authentication")
+            self.assertEqual(FakeClient.create_calls, 0)
+            self.assertFalse(registry.exists())
+
+    def test_successful_post_is_persisted_and_rerun_is_duplicate_safe(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tweet, forecast, status, prepared, registry = self._paths(tmp)
+            self._write_context(tweet, forecast)
+            cookies = json.dumps({"auth_token": "abc", "ct0": "def"})
+            env = {post_to_x.COOKIES_ENV: cookies, "GITHUB_RUN_ID": "100"}
+            with (
+                patch.object(post_to_x, "TWEET_PATH", tweet),
+                patch.object(post_to_x, "FORECAST_PATH", forecast),
+                patch.object(post_to_x, "STATUS_PATH", status),
+                patch.object(post_to_x, "PREPARED_PATH", prepared),
+                patch.object(post_to_x, "REGISTRY_PATH", registry),
+                patch.object(post_to_x, "Client", FakeClient),
+                patch.object(post_to_x, "apply_twikit_compat", lambda: None),
+                patch.dict(os.environ, env, clear=True),
+            ):
+                self.assertTrue(asyncio.run(post_to_x.prepare_post()))
+                asyncio.run(post_to_x.publish_post())
+                self.assertFalse(asyncio.run(post_to_x.prepare_post()))
+
+            result = json.loads(status.read_text(encoding="utf-8"))
+            self.assertEqual(result["status"], "duplicate_skipped")
+            self.assertEqual(result["post_id"], "123456")
+            self.assertEqual(FakeClient.create_calls, 1)
+            records = XPostRegistry(registry)
+            item = next(iter(records.data["posts"].values()))
+            self.assertEqual(item["status"], "posted")
+            self.assertEqual(item["experiment_run_id"], "exp-1")
+            self.assertEqual(item["github_run_id"], "100")
+
+    def test_ambiguous_response_failure_locks_future_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tweet, forecast, status, prepared, registry = self._paths(tmp)
+            self._write_context(tweet, forecast)
+            FakeClient.publish_error = KeyError("urls")
+            cookies = json.dumps({"auth_token": "abc", "ct0": "def"})
+            env = {post_to_x.COOKIES_ENV: cookies, "GITHUB_RUN_ID": "100"}
+            with (
+                patch.object(post_to_x, "TWEET_PATH", tweet),
+                patch.object(post_to_x, "FORECAST_PATH", forecast),
+                patch.object(post_to_x, "STATUS_PATH", status),
+                patch.object(post_to_x, "PREPARED_PATH", prepared),
+                patch.object(post_to_x, "REGISTRY_PATH", registry),
+                patch.object(post_to_x, "Client", FakeClient),
+                patch.object(post_to_x, "apply_twikit_compat", lambda: None),
+                patch.dict(os.environ, env, clear=True),
+            ):
+                self.assertTrue(asyncio.run(post_to_x.prepare_post()))
+                with self.assertRaises(KeyError):
+                    asyncio.run(post_to_x.publish_post())
+                FakeClient.publish_error = None
+                self.assertFalse(asyncio.run(post_to_x.prepare_post()))
+
+            result = json.loads(status.read_text(encoding="utf-8"))
+            self.assertEqual(result["status"], "duplicate_locked")
+            item = next(iter(XPostRegistry(registry).data["posts"].values()))
+            self.assertEqual(item["status"], "ambiguous")
+            self.assertEqual(item["failure_class"], "response_parsing")
+            self.assertEqual(FakeClient.create_calls, 1)
 
 
 if __name__ == "__main__":

--- a/test_x_post_registry.py
+++ b/test_x_post_registry.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for the durable X publication idempotency registry."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from x_post_registry import XPostRegistry, idempotency_key
+
+
+class XPostRegistryTests(unittest.TestCase):
+    def test_key_is_deterministic_and_content_sensitive(self) -> None:
+        first = idempotency_key("2026-09-05T20:00:00+00:00", "BTC forecast")
+        self.assertEqual(first, idempotency_key("2026-09-05T20:00:00+00:00", "BTC forecast"))
+        self.assertNotEqual(first, idempotency_key("2026-09-05T21:00:00+00:00", "BTC forecast"))
+        self.assertNotEqual(first, idempotency_key("2026-09-05T20:00:00+00:00", "BTC forecast!"))
+
+    def test_posted_reservation_is_never_publishable_again(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "registry.json"
+            registry = XPostRegistry(path)
+            key = idempotency_key("2026-09-05T20:00:00+00:00", "hello")
+            first = registry.reserve(
+                key=key,
+                origin_at="2026-09-05T20:00:00+00:00",
+                text="hello",
+                experiment_run_id="exp-1",
+                configuration_id="cfg-1",
+                github_run_id="100",
+            )
+            self.assertEqual(first["action"], "publish")
+            registry.mark_posted(key, "123")
+
+            second = XPostRegistry(path).reserve(
+                key=key,
+                origin_at="2026-09-05T20:00:00+00:00",
+                text="hello",
+                experiment_run_id="exp-2",
+                configuration_id="cfg-1",
+                github_run_id="101",
+            )
+            self.assertEqual(second["action"], "duplicate")
+            self.assertEqual(second["record"]["post_id"], "123")
+
+    def test_ambiguous_attempt_is_locked_but_auth_failure_can_retry(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "registry.json"
+            registry = XPostRegistry(path)
+            key = idempotency_key("2026-09-05T20:00:00+00:00", "hello")
+            registry.reserve(
+                key=key,
+                origin_at="2026-09-05T20:00:00+00:00",
+                text="hello",
+                experiment_run_id="exp-1",
+                configuration_id="cfg-1",
+                github_run_id="100",
+            )
+            registry.mark_failed(
+                key,
+                failure_class="authentication",
+                error_type="Unauthorized",
+                error_message="401",
+                ambiguous=False,
+            )
+            retry = registry.reserve(
+                key=key,
+                origin_at="2026-09-05T20:00:00+00:00",
+                text="hello",
+                experiment_run_id="exp-1",
+                configuration_id="cfg-1",
+                github_run_id="101",
+            )
+            self.assertEqual(retry["action"], "publish")
+            self.assertTrue(retry["retry"])
+            self.assertEqual(retry["record"]["attempts"], 2)
+
+            registry.mark_failed(
+                key,
+                failure_class="response_parsing",
+                error_type="KeyError",
+                error_message="urls",
+                ambiguous=True,
+            )
+            locked = registry.reserve(
+                key=key,
+                origin_at="2026-09-05T20:00:00+00:00",
+                text="hello",
+                experiment_run_id="exp-1",
+                configuration_id="cfg-1",
+                github_run_id="102",
+            )
+            self.assertEqual(locked["action"], "locked")
+            self.assertEqual(locked["record"]["status"], "ambiguous")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/x_post_registry.py
+++ b/x_post_registry.py
@@ -77,7 +77,9 @@ class XPostRegistry:
         posts: dict[str, Any] = self.data["posts"]
         existing = posts.get(key)
         if isinstance(existing, dict):
-            if existing.get("origin_at") != origin_at or existing.get("content_sha256") != content_sha256(text):
+            if existing.get("origin_at") != origin_at or existing.get(
+                "content_sha256"
+            ) != content_sha256(text):
                 raise RuntimeError("Idempotency-key collision with different forecast content")
             failure_class = existing.get("failure_class")
             if existing.get("status") == "failed" and failure_class in RETRYABLE_FAILURE_CLASSES:

--- a/x_post_registry.py
+++ b/x_post_registry.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Durable idempotency registry for forecast posts published to X."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REGISTRY_VERSION = 1
+DEFAULT_REGISTRY_PATH = Path(".state/x_post_registry.json")
+RETRYABLE_FAILURE_CLASSES = {"authentication", "rate_limit"}
+BLOCKING_STATUSES = {"reserved", "ambiguous", "posted"}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def content_sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def idempotency_key(origin_at: str, text: str) -> str:
+    payload = f"{origin_at}\n{text}".encode("utf-8")
+    return "xpost-" + hashlib.sha256(payload).hexdigest()
+
+
+class XPostRegistry:
+    """Small JSON registry persisted beside the durable forecast-history asset."""
+
+    def __init__(self, path: Path | str = DEFAULT_REGISTRY_PATH) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.data = self._load()
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.exists():
+            return {"version": REGISTRY_VERSION, "posts": {}}
+        payload = json.loads(self.path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise RuntimeError("X post registry must contain a JSON object")
+        version = payload.get("version")
+        if version != REGISTRY_VERSION:
+            raise RuntimeError(
+                f"Unsupported X post registry version {version!r}; expected {REGISTRY_VERSION}"
+            )
+        posts = payload.get("posts")
+        if not isinstance(posts, dict):
+            raise RuntimeError("X post registry is missing its posts mapping")
+        return payload
+
+    def _save(self) -> None:
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(json.dumps(self.data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        tmp.replace(self.path)
+
+    def get(self, key: str) -> dict[str, Any] | None:
+        item = self.data["posts"].get(key)
+        return dict(item) if isinstance(item, dict) else None
+
+    def reserve(
+        self,
+        *,
+        key: str,
+        origin_at: str,
+        text: str,
+        experiment_run_id: str | None,
+        configuration_id: str | None,
+        github_run_id: str | None,
+        provider: str = "twikit",
+    ) -> dict[str, Any]:
+        now = _utc_now()
+        posts: dict[str, Any] = self.data["posts"]
+        existing = posts.get(key)
+        if isinstance(existing, dict):
+            if existing.get("origin_at") != origin_at or existing.get("content_sha256") != content_sha256(text):
+                raise RuntimeError("Idempotency-key collision with different forecast content")
+            failure_class = existing.get("failure_class")
+            if existing.get("status") == "failed" and failure_class in RETRYABLE_FAILURE_CLASSES:
+                existing["status"] = "reserved"
+                existing["updated_at"] = now
+                existing["github_run_id"] = github_run_id
+                existing["attempts"] = int(existing.get("attempts", 1)) + 1
+                existing["failure_class"] = None
+                existing["error_type"] = None
+                existing["error_message"] = None
+                self._save()
+                return {"action": "publish", "retry": True, "record": dict(existing)}
+            action = "duplicate" if existing.get("status") == "posted" else "locked"
+            return {"action": action, "retry": False, "record": dict(existing)}
+
+        record: dict[str, Any] = {
+            "idempotency_key": key,
+            "origin_at": origin_at,
+            "content_sha256": content_sha256(text),
+            "experiment_run_id": experiment_run_id,
+            "configuration_id": configuration_id,
+            "github_run_id": github_run_id,
+            "provider": provider,
+            "status": "reserved",
+            "post_id": None,
+            "failure_class": None,
+            "error_type": None,
+            "error_message": None,
+            "attempts": 1,
+            "created_at": now,
+            "updated_at": now,
+            "posted_at": None,
+        }
+        posts[key] = record
+        self._save()
+        return {"action": "publish", "retry": False, "record": dict(record)}
+
+    def mark_posted(self, key: str, post_id: str) -> dict[str, Any]:
+        record = self._require(key)
+        now = _utc_now()
+        record.update(
+            {
+                "status": "posted",
+                "post_id": str(post_id),
+                "failure_class": None,
+                "error_type": None,
+                "error_message": None,
+                "posted_at": now,
+                "updated_at": now,
+            }
+        )
+        self._save()
+        return dict(record)
+
+    def mark_failed(
+        self,
+        key: str,
+        *,
+        failure_class: str,
+        error_type: str,
+        error_message: str,
+        ambiguous: bool,
+    ) -> dict[str, Any]:
+        record = self._require(key)
+        record.update(
+            {
+                "status": "ambiguous" if ambiguous else "failed",
+                "failure_class": failure_class,
+                "error_type": error_type,
+                "error_message": error_message,
+                "updated_at": _utc_now(),
+            }
+        )
+        self._save()
+        return dict(record)
+
+    def _require(self, key: str) -> dict[str, Any]:
+        record = self.data["posts"].get(key)
+        if not isinstance(record, dict):
+            raise RuntimeError(f"No X post reservation exists for {key}")
+        return record
+
+    def stats(self) -> dict[str, int]:
+        counts = {"reserved": 0, "posted": 0, "failed": 0, "ambiguous": 0}
+        for item in self.data["posts"].values():
+            if isinstance(item, dict) and item.get("status") in counts:
+                counts[str(item["status"])] += 1
+        return counts


### PR DESCRIPTION
## Summary
- add a durable JSON idempotency registry keyed by forecast origin + exact post content
- preflight the authenticated Twikit session before reserving or publishing
- persist reservations to the forecast-history Release before any X write so retries fail closed instead of duplicating posts
- persist successful X post IDs with experiment/configuration/GitHub run metadata
- classify authentication, rate-limit, response-parsing, network and provider failures
- lock ambiguous attempts against automatic replay while allowing clearly rejected auth/rate-limit attempts to retry
- add unit coverage for duplicate, retry, expired-session and ambiguous-response paths
- document the two-phase publication and recovery behavior

Closes #38