### PR TITLE
Make ensemble weighting correlation-aware

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,8 @@ jobs:
         run: |
           mypy --follow-imports=skip \
             conformal_calibration.py \
+            correlation_backtest.py \
+            correlation_weighting.py \
             drift_detection.py \
             experiment_manifest.py \
             history_audit.py \

--- a/CORRELATION_WEIGHTING.md
+++ b/CORRELATION_WEIGHTING.md
@@ -1,0 +1,19 @@
+# Correlation-aware ensemble weighting
+
+The production ensemble first computes the existing durable adaptive weights, then applies a conservative diversification overlay using rolling **signed residual correlations** for the same forecast horizon.
+
+Only paired matured forecasts are eligible. Residuals are aligned by forecast origin, so no future target can enter a correlation estimate. Positive residual correlations contribute to a redundancy score; negative correlations are not penalized. Each penalty is shrunk toward 1 while samples are sparse, then the existing 3% floor / 55% cap normalization is reapplied.
+
+Defaults:
+
+- `BTC_CORRELATION_HISTORY_LIMIT=120`
+- `BTC_CORRELATION_MIN_SAMPLES=12`
+- `BTC_CORRELATION_FULL_SAMPLES=36`
+- `BTC_CORRELATION_PENALTY_STRENGTH=0.55`
+- `BTC_CORRELATION_MAX_BLEND=0.70`
+
+When paired history is insufficient, weighting is exactly the current adaptive policy. Drift/static fallback behavior remains authoritative.
+
+## Evaluation
+
+Weighting diagnostics include the base adaptive weights, pair sample counts, residual correlation matrix, redundancy score, penalty and final weight for every model. Walk-forward evaluation reports the current adaptive ensemble and the correlation-aware ensemble on the same validation origins, alongside persistence and the rest of the benchmark suite.

--- a/correlation_backtest.py
+++ b/correlation_backtest.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Walk-forward comparison of current and correlation-aware ensemble policies.
+
+The evaluator consumes frozen model predictions, so both policies see identical
+predictions and actuals. At each origin it exposes only target outcomes whose
+timestamp is no later than that origin, preserving the production no-lookahead
+contract while making the weighting-policy comparison cheap and reproducible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from adaptive_weighting import adaptive_model_weights
+from correlation_weighting import correlation_aware_model_weights
+from forecast_engine import TARGET_HOURS
+
+
+def _weighted_ensemble_price(
+    current: float,
+    model_predictions: dict[str, dict[str, dict[str, float]]],
+    horizon: str,
+    weights: dict[str, float],
+) -> float:
+    """Mirror production's normalized weighted geometric price ensemble."""
+    weighted_log_changes = 0.0
+    total_weight = 0.0
+    for name, weight in weights.items():
+        if weight <= 0:
+            continue
+        price = float(model_predictions[name][horizon]["price_usd"])
+        weighted_log_changes += weight * math.log(price / current)
+        total_weight += weight
+    if total_weight <= 0:
+        raise ValueError("ensemble weights must contain a positive value")
+    return current * math.exp(weighted_log_changes / total_weight)
+
+
+def _score(current: float, predicted: float, actual: float) -> dict[str, float]:
+    predicted_change = predicted - current
+    actual_change = actual - current
+    return {
+        "absolute_error_pct": abs(predicted - actual) / actual * 100.0,
+        "direction_correct": float(
+            (predicted_change > 0 and actual_change > 0)
+            or (predicted_change < 0 and actual_change < 0)
+            or (predicted_change == 0 and actual_change == 0)
+        ),
+    }
+
+
+def _aggregate(scores: list[dict[str, float]]) -> dict[str, float | int | None]:
+    if not scores:
+        return {"samples": 0, "mae_pct": None, "direction_accuracy": None}
+    return {
+        "samples": len(scores),
+        "mae_pct": round(float(np.mean([item["absolute_error_pct"] for item in scores])), 6),
+        "direction_accuracy": round(
+            float(np.mean([item["direction_correct"] for item in scores])), 6
+        ),
+    }
+
+
+def _history_snapshot(sample: dict[str, Any]) -> dict[str, Any]:
+    forecast = sample["forecast"]
+    return {
+        "latest_close_at": forecast["latest_close_at"],
+        "latest_close_usd": forecast["latest_close_usd"],
+        "regime": forecast["regime"],
+        "model_predictions": forecast["model_predictions"],
+        "predictions": forecast.get("predictions", {}),
+        "model_weights": forecast.get("model_weights", {}),
+        "_outcomes": forecast.get("_outcomes", {}),
+    }
+
+
+def compare_frozen_samples(
+    samples: list[dict[str, Any]],
+    actual_by_timestamp: dict[int, float],
+    *,
+    history_limit: int = 200,
+) -> dict[str, Any]:
+    """Replay both weighting policies sequentially on identical frozen origins."""
+    current_scores: dict[str, list[dict[str, float]]] = {
+        f"{hour}h": [] for hour in TARGET_HOURS
+    }
+    correlation_scores: dict[str, list[dict[str, float]]] = {
+        f"{hour}h": [] for hour in TARGET_HOURS
+    }
+    history: list[dict[str, Any]] = []
+    policy_modes: dict[str, list[str]] = {f"{hour}h": [] for hour in TARGET_HOURS}
+
+    ordered = sorted(samples, key=lambda item: int(item["origin_timestamp"]))
+    for sample in ordered:
+        timestamp = int(sample["origin_timestamp"])
+        current = float(sample["current_price"])
+        forecast = sample["forecast"]
+        regime = str(forecast["regime"])
+        model_predictions = forecast["model_predictions"]
+        model_names = list(model_predictions)
+        visible_actuals = {
+            target: value for target, value in actual_by_timestamp.items() if target <= timestamp
+        }
+
+        for hour in TARGET_HOURS:
+            horizon = f"{hour}h"
+            actual = float(sample["actuals"][horizon])
+            current_weights, _ = adaptive_model_weights(
+                model_names,
+                regime,
+                hour,
+                history,
+                visible_actuals,
+                history_limit=history_limit,
+            )
+            correlation_weights, diagnostics = correlation_aware_model_weights(
+                model_names,
+                regime,
+                hour,
+                history,
+                visible_actuals,
+                history_limit=history_limit,
+            )
+            current_price = _weighted_ensemble_price(
+                current, model_predictions, horizon, current_weights
+            )
+            correlation_price = _weighted_ensemble_price(
+                current, model_predictions, horizon, correlation_weights
+            )
+            current_scores[horizon].append(_score(current, current_price, actual))
+            correlation_scores[horizon].append(_score(current, correlation_price, actual))
+            policy_modes[horizon].append(str(diagnostics.get("correlation_mode")))
+
+        history.append(_history_snapshot(sample))
+        history = history[-history_limit:]
+
+    by_horizon: dict[str, Any] = {}
+    for horizon in current_scores:
+        current_metrics = _aggregate(current_scores[horizon])
+        correlation_metrics = _aggregate(correlation_scores[horizon])
+        current_mae = current_metrics["mae_pct"]
+        correlation_mae = correlation_metrics["mae_pct"]
+        by_horizon[horizon] = {
+            "current_adaptive": current_metrics,
+            "correlation_aware": correlation_metrics,
+            "correlation_minus_current_mae_pct": (
+                round(float(correlation_mae) - float(current_mae), 6)
+                if correlation_mae is not None and current_mae is not None
+                else None
+            ),
+            "active_correlation_origins": sum(mode == "active" for mode in policy_modes[horizon]),
+        }
+
+    deltas = [
+        float(item["correlation_minus_current_mae_pct"])
+        for item in by_horizon.values()
+        if item["correlation_minus_current_mae_pct"] is not None
+    ]
+    return {
+        "samples": len(ordered),
+        "history_limit": history_limit,
+        "by_horizon": by_horizon,
+        "mean_mae_delta_pct": round(float(np.mean(deltas)), 6) if deltas else None,
+        "interpretation": "negative MAE delta favors correlation-aware weighting",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compare adaptive and correlation-aware weighting on frozen samples"
+    )
+    parser.add_argument("--samples-json", type=Path, required=True)
+    parser.add_argument("--actuals-json", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("correlation_backtest_report.json"))
+    args = parser.parse_args()
+
+    samples = json.loads(args.samples_json.read_text(encoding="utf-8"))
+    raw_actuals = json.loads(args.actuals_json.read_text(encoding="utf-8"))
+    if not isinstance(samples, list) or not isinstance(raw_actuals, dict):
+        raise ValueError("samples must be a list and actuals must be an object")
+    actuals = {int(key): float(value) for key, value in raw_actuals.items()}
+    report = compare_frozen_samples([item for item in samples if isinstance(item, dict)], actuals)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/correlation_backtest.py
+++ b/correlation_backtest.py
@@ -87,9 +87,7 @@ def compare_frozen_samples(
     history_limit: int = 200,
 ) -> dict[str, Any]:
     """Replay both weighting policies sequentially on identical frozen origins."""
-    current_scores: dict[str, list[dict[str, float]]] = {
-        f"{hour}h": [] for hour in TARGET_HOURS
-    }
+    current_scores: dict[str, list[dict[str, float]]] = {f"{hour}h": [] for hour in TARGET_HOURS}
     correlation_scores: dict[str, list[dict[str, float]]] = {
         f"{hour}h": [] for hour in TARGET_HOURS
     }

--- a/correlation_weighting.py
+++ b/correlation_weighting.py
@@ -1,0 +1,282 @@
+"""Correlation-aware overlay for adaptive BTC ensemble weights.
+
+The base adaptive policy scores each model independently. This module adds a
+bounded diversification penalty based only on paired, matured residuals that
+were available at the forecast origin. Sparse estimates shrink back to the
+base policy, and the existing weight floor/cap remain authoritative.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+
+import numpy as np
+
+from adaptive_weighting import (
+    ADAPTIVE_MAX_WEIGHT,
+    ADAPTIVE_MIN_WEIGHT,
+    _bounded_normalize,
+    adaptive_model_weights as base_adaptive_model_weights,
+)
+
+DEFAULT_CORRELATION_HISTORY_LIMIT = int(os.getenv("BTC_CORRELATION_HISTORY_LIMIT", "120"))
+CORRELATION_MIN_SAMPLES = int(os.getenv("BTC_CORRELATION_MIN_SAMPLES", "12"))
+CORRELATION_FULL_SAMPLES = int(os.getenv("BTC_CORRELATION_FULL_SAMPLES", "36"))
+CORRELATION_STRENGTH = float(os.getenv("BTC_CORRELATION_PENALTY_STRENGTH", "0.55"))
+MAX_CORRELATION_BLEND = float(os.getenv("BTC_CORRELATION_MAX_BLEND", "0.70"))
+
+
+def _origin(snapshot: dict[str, Any]) -> datetime | None:
+    try:
+        value = datetime.fromisoformat(str(snapshot["latest_close_at"]).replace("Z", "+00:00"))
+    except (KeyError, TypeError, ValueError):
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _actual(
+    snapshot: dict[str, Any],
+    horizon: str,
+    model_name: str,
+    hour: int,
+    actual_by_timestamp: dict[int, float],
+) -> float | None:
+    try:
+        value = float(snapshot["_outcomes"][horizon][model_name]["actual_target_price_usd"])
+        if value > 0:
+            return value
+    except (KeyError, TypeError, ValueError):
+        pass
+    origin = _origin(snapshot)
+    if origin is None:
+        return None
+    fallback = actual_by_timestamp.get(int(origin.timestamp()) + hour * 3600)
+    if fallback is None:
+        return None
+    actual = float(fallback)
+    return actual if actual > 0 else None
+
+
+def residual_history(
+    history: list[dict[str, Any]],
+    actual_by_timestamp: dict[int, float],
+    model_names: list[str],
+    hour: int,
+    *,
+    history_limit: int = DEFAULT_CORRELATION_HISTORY_LIMIT,
+) -> dict[str, dict[str, float]]:
+    """Map model -> origin -> signed percentage residual for matured rows."""
+    horizon = f"{hour}h"
+    result: dict[str, dict[str, float]] = {name: {} for name in model_names}
+    complete_origins = 0
+    for snapshot in reversed(history):
+        origin = _origin(snapshot)
+        if origin is None:
+            continue
+        origin_key = origin.isoformat()
+        had_sample = False
+        for name in model_names:
+            try:
+                predicted = float(snapshot["model_predictions"][name][horizon]["price_usd"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            actual = _actual(snapshot, horizon, name, hour, actual_by_timestamp)
+            if actual is None:
+                continue
+            result[name][origin_key] = (predicted - actual) / actual
+            had_sample = True
+        if had_sample:
+            complete_origins += 1
+        if complete_origins >= history_limit:
+            break
+    return result
+
+
+def residual_correlation_matrix(
+    residuals: dict[str, dict[str, float]],
+    *,
+    min_samples: int = CORRELATION_MIN_SAMPLES,
+) -> tuple[dict[str, dict[str, float | None]], dict[str, dict[str, int]]]:
+    """Compute pairwise residual correlations on aligned matured origins."""
+    names = list(residuals)
+    correlations: dict[str, dict[str, float | None]] = {name: {} for name in names}
+    samples: dict[str, dict[str, int]] = {name: {} for name in names}
+    for left in names:
+        for right in names:
+            common = sorted(set(residuals[left]) & set(residuals[right]))
+            samples[left][right] = len(common)
+            if left == right:
+                correlations[left][right] = 1.0 if common else None
+                continue
+            if len(common) < min_samples:
+                correlations[left][right] = None
+                continue
+            x = np.asarray([residuals[left][origin] for origin in common], dtype=float)
+            y = np.asarray([residuals[right][origin] for origin in common], dtype=float)
+            if float(np.std(x)) <= 1e-12 or float(np.std(y)) <= 1e-12:
+                correlations[left][right] = None
+                continue
+            correlations[left][right] = float(np.corrcoef(x, y)[0, 1])
+    return correlations, samples
+
+
+def _progress(sample_count: int) -> float:
+    if sample_count < CORRELATION_MIN_SAMPLES:
+        return 0.0
+    return min(
+        1.0,
+        max(
+            0.0,
+            (sample_count - CORRELATION_MIN_SAMPLES)
+            / max(1, CORRELATION_FULL_SAMPLES - CORRELATION_MIN_SAMPLES),
+        ),
+    )
+
+
+def correlation_penalties(
+    base_weights: dict[str, float],
+    correlations: dict[str, dict[str, float | None]],
+    pair_samples: dict[str, dict[str, int]],
+) -> tuple[dict[str, float], dict[str, Any]]:
+    """Calculate sample-shrunk redundancy penalties for each active model."""
+    penalties: dict[str, float] = {}
+    diagnostics: dict[str, Any] = {}
+    for name, weight in base_weights.items():
+        weighted_redundancy = 0.0
+        peer_weight = 0.0
+        usable_samples: list[int] = []
+        for peer, peer_base_weight in base_weights.items():
+            if peer == name or peer_base_weight <= 0:
+                continue
+            correlation = correlations.get(name, {}).get(peer)
+            if correlation is None:
+                continue
+            positive_correlation = max(0.0, float(correlation))
+            weighted_redundancy += peer_base_weight * positive_correlation**2
+            peer_weight += peer_base_weight
+            usable_samples.append(pair_samples.get(name, {}).get(peer, 0))
+        redundancy = weighted_redundancy / peer_weight if peer_weight > 0 else 0.0
+        sample_count = min(usable_samples) if usable_samples else 0
+        blend = MAX_CORRELATION_BLEND * _progress(sample_count)
+        full_penalty = 1.0 / (1.0 + CORRELATION_STRENGTH * redundancy)
+        penalty = 1.0 - blend * (1.0 - full_penalty)
+        penalties[name] = penalty
+        diagnostics[name] = {
+            "base_weight": round(weight, 6),
+            "redundancy_score": round(redundancy, 6),
+            "paired_samples": sample_count,
+            "correlation_blend": round(blend, 6),
+            "penalty": round(penalty, 6),
+        }
+    return penalties, diagnostics
+
+
+def correlation_aware_model_weights(
+    model_names: list[str],
+    regime: str,
+    hour: int,
+    history: list[dict[str, Any]],
+    actual_by_timestamp: dict[int, float],
+    enabled: bool = True,
+    history_limit: int | None = None,
+    confidence: float = 1.0,
+) -> tuple[dict[str, float], dict[str, Any]]:
+    """Apply a conservative residual-correlation overlay to adaptive weights."""
+    base_weights, base_diagnostics = base_adaptive_model_weights(
+        model_names,
+        regime,
+        hour,
+        history,
+        actual_by_timestamp,
+        enabled=enabled,
+        history_limit=history_limit,
+        confidence=confidence,
+    )
+    residuals = residual_history(
+        history,
+        actual_by_timestamp,
+        model_names,
+        hour,
+        history_limit=max(
+            CORRELATION_MIN_SAMPLES,
+            int(history_limit or DEFAULT_CORRELATION_HISTORY_LIMIT),
+        ),
+    )
+    correlations, pair_samples = residual_correlation_matrix(residuals)
+    penalties, model_diagnostics = correlation_penalties(base_weights, correlations, pair_samples)
+    usable_pairs = [
+        pair_samples[left][right]
+        for left in model_names
+        for right in model_names
+        if left < right and correlations[left][right] is not None
+    ]
+
+    if not enabled or base_diagnostics.get("mode") != "adaptive" or not usable_pairs:
+        diagnostics = {
+            **base_diagnostics,
+            "correlation_mode": "base_policy",
+            "correlation_reason": (
+                "disabled"
+                if not enabled
+                else "base_policy_not_adaptive"
+                if base_diagnostics.get("mode") != "adaptive"
+                else "insufficient_paired_history"
+            ),
+            "correlation_min_samples": CORRELATION_MIN_SAMPLES,
+            "correlation_history_limit": int(history_limit or DEFAULT_CORRELATION_HISTORY_LIMIT),
+            "residual_correlations": correlations,
+            "residual_pair_samples": pair_samples,
+            "correlation_models": model_diagnostics,
+        }
+        return base_weights, diagnostics
+
+    adjusted_raw = {name: base_weights[name] * penalties[name] for name in model_names}
+    final = _bounded_normalize(adjusted_raw, ADAPTIVE_MIN_WEIGHT, ADAPTIVE_MAX_WEIGHT)
+    diagnostics = {
+        **base_diagnostics,
+        "mode": "correlation_aware_adaptive",
+        "correlation_mode": "active",
+        "correlation_min_samples": CORRELATION_MIN_SAMPLES,
+        "correlation_history_limit": int(history_limit or DEFAULT_CORRELATION_HISTORY_LIMIT),
+        "minimum_usable_pair_samples": min(usable_pairs),
+        "residual_correlations": correlations,
+        "residual_pair_samples": pair_samples,
+        "correlation_models": {
+            name: {
+                **model_diagnostics[name],
+                "final_weight": round(final[name], 6),
+                "weight_delta": round(final[name] - base_weights[name], 6),
+            }
+            for name in model_names
+        },
+    }
+    return final, diagnostics
+
+
+def compare_weight_policies(
+    model_names: list[str],
+    regime: str,
+    hour: int,
+    history: list[dict[str, Any]],
+    actual_by_timestamp: dict[int, float],
+) -> dict[str, Any]:
+    """Machine-readable base-vs-correlation policy comparison for backtests."""
+    base, base_diagnostics = base_adaptive_model_weights(
+        model_names, regime, hour, history, actual_by_timestamp
+    )
+    diversified, diversified_diagnostics = correlation_aware_model_weights(
+        model_names, regime, hour, history, actual_by_timestamp
+    )
+    return {
+        "horizon": f"{hour}h",
+        "base_mode": base_diagnostics.get("mode"),
+        "correlation_mode": diversified_diagnostics.get("correlation_mode"),
+        "base_weights": base,
+        "correlation_aware_weights": diversified,
+        "weight_delta": {name: diversified[name] - base[name] for name in model_names},
+        "diagnostics": diversified_diagnostics,
+    }

--- a/test_correlation_backtest.py
+++ b/test_correlation_backtest.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Tests for the frozen-sample correlation weighting backtest."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from correlation_backtest import compare_frozen_samples
+
+
+class CorrelationBacktestTests(unittest.TestCase):
+    def test_report_compares_policies_on_same_origins_without_future_actuals(self) -> None:
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        samples = []
+        actuals: dict[int, float] = {}
+        for i in range(24):
+            origin = start + timedelta(hours=i * 2)
+            current = 100.0 + i * 0.1
+            model_predictions = {}
+            for name, offset in (
+                ("timesfm_168h", 0.3),
+                ("timesfm_336h", 0.31),
+                ("ar1", -0.2 if i % 2 else 0.2),
+                ("persistence", 0.0),
+            ):
+                model_predictions[name] = {
+                    f"{hour}h": {"price_usd": current + offset} for hour in (2, 4, 8, 16)
+                }
+            sample_actuals = {}
+            for hour in (2, 4, 8, 16):
+                target = int((origin + timedelta(hours=hour)).timestamp())
+                value = current + 0.15
+                actuals[target] = value
+                sample_actuals[f"{hour}h"] = value
+            samples.append(
+                {
+                    "origin_timestamp": int(origin.timestamp()),
+                    "current_price": current,
+                    "actuals": sample_actuals,
+                    "forecast": {
+                        "latest_close_at": origin.isoformat(),
+                        "latest_close_usd": current,
+                        "regime": "range",
+                        "model_predictions": model_predictions,
+                        "predictions": {},
+                    },
+                }
+            )
+
+        report = compare_frozen_samples(samples, actuals)
+        self.assertEqual(report["samples"], 24)
+        self.assertEqual(set(report["by_horizon"]), {"2h", "4h", "8h", "16h"})
+        for metrics in report["by_horizon"].values():
+            self.assertEqual(metrics["current_adaptive"]["samples"], 24)
+            self.assertEqual(metrics["correlation_aware"]["samples"], 24)
+            self.assertIn("correlation_minus_current_mae_pct", metrics)
+
+    def test_order_of_input_samples_does_not_change_report(self) -> None:
+        origin = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        model_predictions = {
+            name: {f"{hour}h": {"price_usd": 100.0} for hour in (2, 4, 8, 16)}
+            for name in ("timesfm_168h", "timesfm_336h", "ar1", "persistence")
+        }
+        samples = []
+        actuals: dict[int, float] = {}
+        for i in range(3):
+            at = origin + timedelta(hours=i)
+            sample_actuals = {}
+            for hour in (2, 4, 8, 16):
+                target = int((at + timedelta(hours=hour)).timestamp())
+                actuals[target] = 100.0
+                sample_actuals[f"{hour}h"] = 100.0
+            samples.append(
+                {
+                    "origin_timestamp": int(at.timestamp()),
+                    "current_price": 100.0,
+                    "actuals": sample_actuals,
+                    "forecast": {
+                        "latest_close_at": at.isoformat(),
+                        "latest_close_usd": 100.0,
+                        "regime": "range",
+                        "model_predictions": model_predictions,
+                        "predictions": {},
+                    },
+                }
+            )
+        self.assertEqual(
+            compare_frozen_samples(samples, actuals),
+            compare_frozen_samples(list(reversed(samples)), actuals),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_correlation_weighting.py
+++ b/test_correlation_weighting.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Tests for residual-correlation-aware ensemble weighting."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from correlation_weighting import (
+    CORRELATION_MIN_SAMPLES,
+    correlation_aware_model_weights,
+    correlation_penalties,
+    residual_correlation_matrix,
+    residual_history,
+)
+
+MODELS = ["timesfm_168h", "timesfm_336h", "ar1", "persistence"]
+
+
+def history_rows(
+    count: int, *, include_future: bool = False
+) -> tuple[list[dict], dict[int, float]]:
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    rows = []
+    actuals: dict[int, float] = {}
+    for i in range(count):
+        origin = start + timedelta(hours=i)
+        actual = 100.0 + i * 0.1
+        actuals[int((origin + timedelta(hours=2)).timestamp())] = actual
+        common_error = (i % 5 - 2) * 0.15
+        model_prices = {
+            "timesfm_168h": actual + common_error,
+            "timesfm_336h": actual + common_error * 1.02,
+            "ar1": actual + (0.35 if i % 2 else -0.30),
+            "persistence": 100.0,
+        }
+        rows.append(
+            {
+                "latest_close_at": origin.isoformat(),
+                "latest_close_usd": 100.0,
+                "regime": "range",
+                "model_predictions": {
+                    name: {"2h": {"price_usd": price}} for name, price in model_prices.items()
+                },
+                "predictions": {},
+            }
+        )
+    if include_future:
+        origin = start + timedelta(days=30)
+        rows.append(
+            {
+                "latest_close_at": origin.isoformat(),
+                "latest_close_usd": 100.0,
+                "regime": "range",
+                "model_predictions": {name: {"2h": {"price_usd": 10000.0}} for name in MODELS},
+                "predictions": {},
+            }
+        )
+    return rows, actuals
+
+
+class CorrelationWeightingTests(unittest.TestCase):
+    def test_residual_correlations_use_aligned_matured_origins(self) -> None:
+        history, actuals = history_rows(20, include_future=True)
+        residuals = residual_history(history, actuals, MODELS, 2)
+        correlations, samples = residual_correlation_matrix(residuals)
+        self.assertEqual(samples["timesfm_168h"]["timesfm_336h"], 20)
+        self.assertGreater(correlations["timesfm_168h"]["timesfm_336h"], 0.99)
+        self.assertNotIn(
+            (datetime(2026, 1, 31, tzinfo=timezone.utc)).isoformat(),
+            residuals["timesfm_168h"],
+        )
+
+    def test_sparse_history_leaves_base_policy_unchanged(self) -> None:
+        history, actuals = history_rows(CORRELATION_MIN_SAMPLES - 1)
+        weights, diagnostics = correlation_aware_model_weights(MODELS, "range", 2, history, actuals)
+        self.assertEqual(diagnostics["correlation_mode"], "base_policy")
+        self.assertAlmostEqual(sum(weights.values()), 1.0)
+
+    def test_correlated_models_receive_diversification_penalty(self) -> None:
+        correlations = {
+            "a": {"a": 1.0, "b": 0.99, "c": 0.0},
+            "b": {"a": 0.99, "b": 1.0, "c": 0.0},
+            "c": {"a": 0.0, "b": 0.0, "c": 1.0},
+        }
+        samples = {name: {peer: 50 for peer in correlations} for name in correlations}
+        penalties, diagnostics = correlation_penalties(
+            {"a": 0.35, "b": 0.35, "c": 0.30}, correlations, samples
+        )
+        self.assertLess(penalties["a"], penalties["c"])
+        self.assertLess(penalties["b"], penalties["c"])
+        self.assertGreater(
+            diagnostics["a"]["redundancy_score"], diagnostics["c"]["redundancy_score"]
+        )
+
+    def test_final_weights_respect_existing_bounds(self) -> None:
+        history, actuals = history_rows(45)
+        weights, diagnostics = correlation_aware_model_weights(MODELS, "range", 2, history, actuals)
+        self.assertAlmostEqual(sum(weights.values()), 1.0, places=9)
+        for weight in weights.values():
+            self.assertGreaterEqual(weight, 0.03 - 1e-9)
+            self.assertLessEqual(weight, 0.55 + 1e-9)
+        self.assertIn(diagnostics["correlation_mode"], {"active", "base_policy"})
+
+    def test_policy_is_deterministic(self) -> None:
+        history, actuals = history_rows(45)
+        first = correlation_aware_model_weights(MODELS, "range", 2, history, actuals)
+        second = correlation_aware_model_weights(MODELS, "range", 2, history, actuals)
+        self.assertEqual(first, second)
+
+    def test_unmatured_future_does_not_change_weights(self) -> None:
+        history, actuals = history_rows(45)
+        future_history, future_actuals = history_rows(45, include_future=True)
+        current = correlation_aware_model_weights(MODELS, "range", 2, history, actuals)
+        with_future = correlation_aware_model_weights(
+            MODELS, "range", 2, future_history, future_actuals
+        )
+        self.assertEqual(current, with_future)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validated_entrypoints.py
+++ b/validated_entrypoints.py
@@ -180,11 +180,21 @@ def _instrument_forecast(observer: PipelineObserver, btc_forecast: Any) -> None:
     btc_forecast.ForecastHistoryStore = ObservedForecastHistoryStore
 
 
+def _activate_correlation_policy(target: Any) -> None:
+    """Install the correlation-aware wrapper without coupling core modules to it."""
+    from correlation_weighting import correlation_aware_model_weights
+
+    target.forecast_engine.adaptive_model_weights = correlation_aware_model_weights
+    if hasattr(target, "adaptive_model_weights"):
+        target.adaptive_model_weights = correlation_aware_model_weights
+
+
 def run_forecast(argv: list[str]) -> None:
     if argv:
         raise SystemExit("forecast does not accept positional arguments")
     import btc_forecast
 
+    _activate_correlation_policy(btc_forecast)
     observer = PipelineObserver(run_type="production_forecast")
     _instrument_forecast(observer, btc_forecast)
     try:
@@ -200,6 +210,7 @@ def run_forecast(argv: list[str]) -> None:
 def _patch_backtest_fetch() -> Any:
     import backtest
 
+    _activate_correlation_policy(backtest)
     original_fetch = backtest.fetch_binance_history
 
     def fetch_validated(days: int):


### PR DESCRIPTION
## Summary
- estimate rolling signed residual correlations per horizon from aligned matured forecasts only
- shrink correlation estimates/penalties toward the current adaptive policy while paired history is sparse
- penalize positively correlated model redundancy without penalizing useful negative correlation
- preserve the existing adaptive floors, caps, drift fallback and persistence safeguards
- activate the correlation-aware wrapper in validated production, backtest and optimizer entrypoints
- add a frozen-prediction walk-forward evaluator that compares current adaptive vs correlation-aware weighting on identical origins without future leakage
- expose correlation matrices, paired sample counts, redundancy scores, penalties and final weight deltas in diagnostics
- add unit tests, documentation and type checking

This PR is stacked on #85 / issue #31 and should be merged after #31.

Closes #30