### PR TITLE
Add diversified non-TimesFM ridge forecasting model

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,7 @@ jobs:
             conformal_calibration.py \
             correlation_backtest.py \
             correlation_weighting.py \
+            diversified_model.py \
             drift_detection.py \
             experiment_manifest.py \
             history_audit.py \

--- a/DIVERSIFIED_MODEL.md
+++ b/DIVERSIFIED_MODEL.md
@@ -1,0 +1,24 @@
+# Diversified non-TimesFM model
+
+`ridge_features` is a lightweight direct multi-horizon ridge-regression model intended to add a materially different inductive bias to the TimesFM-heavy ensemble.
+
+For each 2h/4h/8h/16h target it trains on past-only engineered features: lagged log returns, 6/24/72h momentum, mean returns and volatility, hourly range, volume z-score, RSI, and cyclical hour/week signals. A separate ridge fit predicts cumulative log return for each horizon. Training examples are admitted only when the target close already exists in the supplied market window, so the implementation is safe for chronological walk-forward evaluation.
+
+The model uses only NumPy and runs in milliseconds relative to TimesFM inference. Return extrapolation is bounded by recent realized volatility to fail conservatively under ill-conditioned feature windows.
+
+## Production gate
+
+The model is **research-only by default**. Backtest/optimizer entrypoints include it so standalone performance, residual correlation, and ensemble contribution can be measured on the existing purged walk-forward path. Production only includes it when:
+
+```text
+BTC_ENABLE_DIVERSIFIED_MODEL=true
+```
+
+That flag should only be set after the existing statistical-evidence / promotion-policy reports show defensible out-of-sample value. Adding the code therefore does not silently change the production ensemble.
+
+Other configuration:
+
+- `BTC_RIDGE_MIN_TRAIN_SAMPLES=96`
+- `BTC_RIDGE_ALPHA=8.0`
+
+Once enabled, `ridge_features` is returned through the same baseline/model-prediction interface as the statistical baselines, so adaptive and correlation-aware weighting automatically evaluate it under the same floors, caps, persistence fallback and residual-correlation diagnostics.

--- a/diversified_model.py
+++ b/diversified_model.py
@@ -1,0 +1,254 @@
+"""Lightweight non-TimesFM forecasting model for BTC hourly returns.
+
+The model is deliberately simple and CPU-friendly: a direct ridge regression is
+fit independently for each production horizon using engineered, past-only
+features. Training labels are only created when their target close already
+exists inside the input window, so the same implementation is safe in both
+production and chronological walk-forward evaluation.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+from typing import Any, Callable
+
+import numpy as np
+
+MODEL_NAME = "ridge_features"
+TARGET_HOURS = (2, 4, 8, 16)
+MAX_LAG = 72
+DEFAULT_MIN_TRAIN_SAMPLES = int(os.getenv("BTC_RIDGE_MIN_TRAIN_SAMPLES", "96"))
+DEFAULT_RIDGE_ALPHA = float(os.getenv("BTC_RIDGE_ALPHA", "8.0"))
+DEFAULT_INITIAL_PRIOR_WEIGHT = float(os.getenv("BTC_RIDGE_INITIAL_PRIOR_WEIGHT", "0.08"))
+MIN_INITIAL_PRIOR_WEIGHT = 0.03
+MAX_INITIAL_PRIOR_WEIGHT = 0.20
+PRODUCTION_FLAG = "BTC_ENABLE_DIVERSIFIED_MODEL"
+
+StaticWeights = Callable[[list[str], str], dict[str, float]]
+
+
+def production_enabled() -> bool:
+    """Return whether the research model has been explicitly approved for production."""
+    return os.getenv(PRODUCTION_FLAG, "false").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def diversified_static_model_weights(
+    base_function: StaticWeights,
+    model_names: list[str],
+    regime: str,
+    *,
+    initial_weight: float = DEFAULT_INITIAL_PRIOR_WEIGHT,
+) -> dict[str, float]:
+    """Reserve a conservative static prior for the diversified model.
+
+    Adaptive weighting falls back to the static prior until every active model
+    has enough matured history. Without this reservation, adding the ridge model
+    would leave it absent from the prior and the fallback path would raise a
+    KeyError. Existing relative priors are preserved and scaled into the
+    remaining mass.
+    """
+    if MODEL_NAME not in model_names:
+        return base_function(model_names, regime)
+
+    base_names = [name for name in model_names if name != MODEL_NAME]
+    if not base_names:
+        return {MODEL_NAME: 1.0}
+
+    base = dict(base_function(base_names, regime))
+    if not base:
+        raise ValueError("base static weighting returned no weights")
+
+    ridge_weight = float(
+        np.clip(initial_weight, MIN_INITIAL_PRIOR_WEIGHT, MAX_INITIAL_PRIOR_WEIGHT)
+    )
+    base_total = sum(max(0.0, float(weight)) for weight in base.values())
+    if base_total <= 0:
+        raise ValueError("base static weighting must contain positive weight")
+
+    remaining = 1.0 - ridge_weight
+    weights = {
+        name: remaining * max(0.0, float(weight)) / base_total for name, weight in base.items()
+    }
+    weights[MODEL_NAME] = ridge_weight
+    return weights
+
+
+def install_adaptive_prior() -> None:
+    """Install the ridge-aware static prior when adaptive weighting is already loaded."""
+    adaptive_weighting = sys.modules.get("adaptive_weighting")
+    if adaptive_weighting is None:
+        return
+    if bool(getattr(adaptive_weighting, "_ridge_prior_installed", False)):
+        return
+    base_function = getattr(adaptive_weighting, "static_model_weights", None)
+    if base_function is None:
+        return
+
+    def ridge_aware_weights(model_names: list[str], regime: str) -> dict[str, float]:
+        return diversified_static_model_weights(base_function, model_names, regime)
+
+    setattr(adaptive_weighting, "static_model_weights", ridge_aware_weights)
+    setattr(adaptive_weighting, "_ridge_prior_installed", True)
+
+
+def _safe_std(values: np.ndarray) -> float:
+    value = float(np.std(values))
+    return value if math.isfinite(value) and value > 1e-9 else 1.0
+
+
+def _rsi_from_returns(returns: np.ndarray, period: int = 14) -> float:
+    window = returns[-period:]
+    gains = np.clip(window, 0.0, None)
+    losses = np.clip(-window, 0.0, None)
+    avg_gain = float(np.mean(gains))
+    avg_loss = float(np.mean(losses))
+    if avg_loss <= 1e-12:
+        return 100.0 if avg_gain > 0 else 50.0
+    rs = avg_gain / avg_loss
+    return 100.0 - 100.0 / (1.0 + rs)
+
+
+def _feature_at(data: Any, index: int) -> np.ndarray:
+    closes = np.asarray(data.closes, dtype=float)
+    highs = np.asarray(data.highs, dtype=float)
+    lows = np.asarray(data.lows, dtype=float)
+    volumes = np.asarray(data.volumes, dtype=float)
+    if index < MAX_LAG or index >= len(closes):
+        raise ValueError(f"feature index must be in [{MAX_LAG}, {len(closes) - 1}]")
+
+    log_prices = np.log(closes[: index + 1])
+    returns = np.diff(log_prices)
+    last_return = returns[-1]
+    lag_returns = [returns[-lag] for lag in (1, 2, 4, 8, 24)]
+    momentum = [log_prices[-1] - log_prices[-1 - lag] for lag in (6, 24, 72)]
+    mean_returns = [float(np.mean(returns[-window:])) for window in (6, 24, 72)]
+    volatility = [float(np.std(returns[-window:])) for window in (6, 24, 72)]
+
+    close = closes[index]
+    range_fraction = float((highs[index] - lows[index]) / close)
+    volume_window = volumes[index - 23 : index + 1]
+    volume_z = float((volumes[index] - np.mean(volume_window)) / _safe_std(volume_window))
+    rsi_scaled = (_rsi_from_returns(returns) - 50.0) / 50.0
+
+    timestamp = int(data.timestamps[index])
+    hour = (timestamp // 3600) % 24
+    weekday = (timestamp // 86400 + 4) % 7
+    hour_angle = 2.0 * math.pi * hour / 24.0
+    weekday_angle = 2.0 * math.pi * weekday / 7.0
+
+    features = np.asarray(
+        [
+            1.0,
+            last_return,
+            *lag_returns,
+            *momentum,
+            *mean_returns,
+            *volatility,
+            range_fraction,
+            volume_z,
+            rsi_scaled,
+            math.sin(hour_angle),
+            math.cos(hour_angle),
+            math.sin(weekday_angle),
+            math.cos(weekday_angle),
+        ],
+        dtype=float,
+    )
+    if not np.all(np.isfinite(features)):
+        raise ValueError("engineered ridge features contain non-finite values")
+    return features
+
+
+def training_examples(
+    data: Any,
+    horizon: int,
+    *,
+    min_train_samples: int = DEFAULT_MIN_TRAIN_SAMPLES,
+) -> tuple[np.ndarray, np.ndarray, list[int]]:
+    """Build direct-horizon examples whose labels are fully observed in ``data``."""
+    if horizon not in TARGET_HOURS:
+        raise ValueError(f"unsupported horizon: {horizon}")
+    closes = np.asarray(data.closes, dtype=float)
+    latest_index = len(closes) - 1
+    last_training_origin = latest_index - horizon
+    indices = list(range(MAX_LAG, last_training_origin + 1))
+    if len(indices) < min_train_samples:
+        raise ValueError(
+            f"insufficient ridge history for {horizon}h: {len(indices)} < {min_train_samples}"
+        )
+    x = np.vstack([_feature_at(data, index) for index in indices])
+    y = np.asarray(
+        [math.log(closes[index + horizon] / closes[index]) for index in indices],
+        dtype=float,
+    )
+    return x, y, indices
+
+
+def _fit_predict_ridge(
+    x: np.ndarray,
+    y: np.ndarray,
+    latest_features: np.ndarray,
+    *,
+    alpha: float,
+) -> float:
+    if alpha <= 0:
+        raise ValueError("ridge alpha must be positive")
+    intercept = x[:, :1]
+    continuous = x[:, 1:]
+    means = np.mean(continuous, axis=0)
+    stds = np.std(continuous, axis=0)
+    stds = np.where(stds > 1e-9, stds, 1.0)
+    x_scaled = np.concatenate([intercept, (continuous - means) / stds], axis=1)
+    latest_scaled = np.concatenate([latest_features[:1], (latest_features[1:] - means) / stds])
+    penalty = np.eye(x_scaled.shape[1], dtype=float) * alpha
+    penalty[0, 0] = 0.0
+    coefficients = np.linalg.solve(x_scaled.T @ x_scaled + penalty, x_scaled.T @ y)
+    return float(latest_scaled @ coefficients)
+
+
+def ridge_feature_forecast(
+    data: Any,
+    *,
+    alpha: float = DEFAULT_RIDGE_ALPHA,
+    min_train_samples: int = DEFAULT_MIN_TRAIN_SAMPLES,
+) -> dict[str, dict[str, float]]:
+    """Forecast 2h/4h/8h/16h BTC prices with direct ridge regressions."""
+    closes = np.asarray(data.closes, dtype=float)
+    if len(closes) <= MAX_LAG + max(TARGET_HOURS):
+        raise ValueError("market window is too short for ridge forecasting")
+    current_price = float(closes[-1])
+    latest_features = _feature_at(data, len(closes) - 1)
+    recent_returns = np.diff(np.log(closes[-73:]))
+    recent_volatility = max(float(np.std(recent_returns)), 1e-5)
+
+    result: dict[str, dict[str, float]] = {}
+    for horizon in TARGET_HOURS:
+        x, y, _ = training_examples(data, horizon, min_train_samples=min_train_samples)
+        predicted_return = _fit_predict_ridge(x, y, latest_features, alpha=alpha)
+        # Guard against an unstable extrapolation while keeping the model's
+        # relative signal. The bound scales with recent realized volatility.
+        return_limit = max(0.005, 4.0 * recent_volatility * math.sqrt(horizon))
+        predicted_return = float(np.clip(predicted_return, -return_limit, return_limit))
+        predicted_price = current_price * math.exp(predicted_return)
+        result[f"{horizon}h"] = {
+            "price_usd": predicted_price,
+            "predicted_log_return": predicted_return,
+            "training_samples": float(len(y)),
+        }
+    return result
+
+
+def augment_baselines(
+    baseline_function: Any,
+    data: Any,
+    *,
+    enabled: bool,
+) -> dict[str, dict[str, dict[str, float]]]:
+    """Return ordinary baselines plus the ridge member when research/approved."""
+    baselines = dict(baseline_function(data))
+    if enabled:
+        install_adaptive_prior()
+        baselines[MODEL_NAME] = ridge_feature_forecast(data)
+    return baselines

--- a/test_diversified_model.py
+++ b/test_diversified_model.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Tests for the lightweight diversified forecasting model."""
+
+from __future__ import annotations
+
+import os
+import unittest
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+
+from diversified_model import (
+    DEFAULT_INITIAL_PRIOR_WEIGHT,
+    MAX_INITIAL_PRIOR_WEIGHT,
+    MAX_LAG,
+    MODEL_NAME,
+    TARGET_HOURS,
+    augment_baselines,
+    diversified_static_model_weights,
+    production_enabled,
+    ridge_feature_forecast,
+    training_examples,
+)
+
+
+def make_market(count: int = 513) -> SimpleNamespace:
+    start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    index = np.arange(count, dtype=float)
+    closes = 100.0 * np.exp(0.0003 * index + 0.01 * np.sin(index / 12.0))
+    opens = closes * (1.0 - 0.0005)
+    highs = closes * (1.0 + 0.002)
+    lows = closes * (1.0 - 0.002)
+    volumes = 1000.0 + 100.0 * np.sin(index / 7.0) + index * 0.2
+    return SimpleNamespace(
+        timestamps=[int((start + timedelta(hours=int(i))).timestamp()) for i in index],
+        opens=opens,
+        highs=highs,
+        lows=lows,
+        closes=closes,
+        volumes=volumes,
+    )
+
+
+class DiversifiedModelTests(unittest.TestCase):
+    def test_training_labels_never_extend_beyond_available_market_window(self) -> None:
+        data = make_market()
+        for horizon in TARGET_HOURS:
+            _, _, indices = training_examples(data, horizon)
+            self.assertGreaterEqual(indices[0], MAX_LAG)
+            self.assertLessEqual(indices[-1] + horizon, len(data.closes) - 1)
+
+    def test_forecast_covers_all_horizons_with_positive_prices(self) -> None:
+        forecast = ridge_feature_forecast(make_market())
+        self.assertEqual(set(forecast), {"2h", "4h", "8h", "16h"})
+        for value in forecast.values():
+            self.assertGreater(value["price_usd"], 0.0)
+            self.assertGreater(value["training_samples"], 90)
+
+    def test_same_market_window_is_deterministic(self) -> None:
+        data = make_market()
+        self.assertEqual(ridge_feature_forecast(data), ridge_feature_forecast(data))
+
+    def test_future_extension_does_not_change_examples_available_at_prior_origin(self) -> None:
+        original = make_market(300)
+        extended = make_market(320)
+        horizon = 16
+        x_original, y_original, indices_original = training_examples(original, horizon)
+        cutoff = len(original.closes) - 1 - horizon
+        x_extended, y_extended, indices_extended = training_examples(extended, horizon)
+        retained = [i for i, index in enumerate(indices_extended) if index <= cutoff]
+        self.assertEqual(indices_original, [indices_extended[i] for i in retained])
+        np.testing.assert_allclose(x_original, x_extended[retained], rtol=0.0, atol=1e-12)
+        np.testing.assert_allclose(y_original, y_extended[retained], rtol=0.0, atol=1e-12)
+
+    def test_short_history_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            ridge_feature_forecast(make_market(100))
+
+    def test_production_model_is_opt_in(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BTC_ENABLE_DIVERSIFIED_MODEL", None)
+            self.assertFalse(production_enabled())
+        with patch.dict(os.environ, {"BTC_ENABLE_DIVERSIFIED_MODEL": "true"}):
+            self.assertTrue(production_enabled())
+
+    def test_diversified_prior_reserves_weight_and_preserves_base_ratios(self) -> None:
+        def base(model_names: list[str], _regime: str) -> dict[str, float]:
+            raw = {"model_a": 0.6, "model_b": 0.4}
+            return {name: raw[name] for name in model_names}
+
+        weights = diversified_static_model_weights(
+            base, ["model_a", "model_b", MODEL_NAME], "range"
+        )
+        self.assertAlmostEqual(sum(weights.values()), 1.0, places=12)
+        self.assertAlmostEqual(weights[MODEL_NAME], DEFAULT_INITIAL_PRIOR_WEIGHT, places=12)
+        self.assertAlmostEqual(weights["model_a"] / weights["model_b"], 1.5, places=12)
+
+    def test_diversified_prior_is_bounded(self) -> None:
+        def base(model_names: list[str], _regime: str) -> dict[str, float]:
+            return {name: 1.0 / len(model_names) for name in model_names}
+
+        weights = diversified_static_model_weights(
+            base,
+            ["model_a", "model_b", MODEL_NAME],
+            "range",
+            initial_weight=0.99,
+        )
+        self.assertAlmostEqual(weights[MODEL_NAME], MAX_INITIAL_PRIOR_WEIGHT, places=12)
+        self.assertAlmostEqual(sum(weights.values()), 1.0, places=12)
+
+    def test_diversified_prior_is_noop_when_model_is_absent(self) -> None:
+        calls: list[tuple[list[str], str]] = []
+
+        def base(model_names: list[str], regime: str) -> dict[str, float]:
+            calls.append((model_names, regime))
+            return {name: 1.0 / len(model_names) for name in model_names}
+
+        weights = diversified_static_model_weights(base, ["model_a", "model_b"], "trending")
+        self.assertEqual(calls, [(["model_a", "model_b"], "trending")])
+        self.assertEqual(weights, {"model_a": 0.5, "model_b": 0.5})
+
+    def test_augment_baselines_is_research_optional(self) -> None:
+        data = make_market()
+
+        def base(_data):
+            return {"persistence": {f"{hour}h": {"price_usd": 100.0} for hour in TARGET_HOURS}}
+
+        disabled = augment_baselines(base, data, enabled=False)
+        self.assertNotIn(MODEL_NAME, disabled)
+        enabled = augment_baselines(base, data, enabled=True)
+        self.assertIn(MODEL_NAME, enabled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validated_entrypoints.py
+++ b/validated_entrypoints.py
@@ -189,12 +189,31 @@ def _activate_correlation_policy(target: Any) -> None:
         target.adaptive_model_weights = correlation_aware_model_weights
 
 
+def _activate_diversified_model(target: Any, *, research: bool) -> None:
+    """Add the ridge member in research, or in production only after explicit approval."""
+    from diversified_model import augment_baselines, production_enabled
+
+    engine = target.forecast_engine
+    if getattr(engine, "_ridge_baselines_wrapped", False):
+        return
+    enabled = research or production_enabled()
+    original_baselines = engine.baseline_forecasts
+
+    def baselines_with_optional_ridge(data: Any):
+        return augment_baselines(original_baselines, data, enabled=enabled)
+
+    engine.baseline_forecasts = baselines_with_optional_ridge
+    engine._ridge_baselines_wrapped = True
+    engine._ridge_model_enabled = enabled
+
+
 def run_forecast(argv: list[str]) -> None:
     if argv:
         raise SystemExit("forecast does not accept positional arguments")
     import btc_forecast
 
     _activate_correlation_policy(btc_forecast)
+    _activate_diversified_model(btc_forecast, research=False)
     observer = PipelineObserver(run_type="production_forecast")
     _instrument_forecast(observer, btc_forecast)
     try:
@@ -211,6 +230,7 @@ def _patch_backtest_fetch() -> Any:
     import backtest
 
     _activate_correlation_policy(backtest)
+    _activate_diversified_model(backtest, research=True)
     original_fetch = backtest.fetch_binance_history
 
     def fetch_validated(days: int):


### PR DESCRIPTION
## Summary
- add a lightweight NumPy ridge-regression model using past-only engineered market/time features
- fit direct, independent 2h/4h/8h/16h cumulative-return targets with no look-ahead leakage
- keep runtime CPU-friendly and bound unstable return extrapolation by recent realized volatility
- include the ridge model automatically in research backtests/optimizer runs so standalone performance and residual correlation are measured under the existing purged walk-forward path
- keep production inclusion disabled by default and require explicit `BTC_ENABLE_DIVERSIFIED_MODEL=true` approval before it can join the ensemble
- give the new model a conservative 8% initial static prior (configurable, bounded to 3%-20%) while its matured adaptive history is sparse, preserving the relative weights of existing members
- once enabled, feed it through the same adaptive/correlation-aware weighting, floors/caps and persistence safeguards as every other member
- add tests for the fallback prior, bounds, no-lookahead behavior, determinism and production opt-in

This PR is stacked after #86 / issue #30 and should be merged after it.

Closes #32