### PR TITLE
Improve market regime detection with validated features

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,6 +89,8 @@ jobs:
             pipeline_health.py \
             post_to_x.py \
             promotion_policy.py \
+            regime_backtest.py \
+            regime_detection.py \
             schedule_guard.py \
             statistical_significance.py \
             x_post_registry.py

--- a/REGIME_DETECTION.md
+++ b/REGIME_DETECTION.md
@@ -1,0 +1,29 @@
+# Validated market regime detection
+
+The production regime classifier keeps the existing stable labels (`range`, `trending`, `high_volatility`) but replaces the original two-rule heuristic with an interpretable score-state detector built from the validated feature pipeline.
+
+The detector combines:
+
+- 6h/24h/7d realized-volatility ratios
+- 6h/24h/7d momentum normalized by realized volatility
+- 24h average candle range
+- 7d volume z-score
+- RSI displacement and multi-window momentum direction consistency
+
+Material thresholds and deadbands are fixed in code rather than fit on the evaluation period. The legacy heuristic remains available as `heuristic_regime`, and a deterministic fixed-prototype state classifier is included as a clustering-style research alternative.
+
+## Transition behavior
+
+`transition_churn()` reports state-change counts/rates. `smooth_regime_sequence()` provides a two-observation confirmation mechanism for offline sequence diagnostics so single-sample state spikes can be quantified. The production detector itself remains stateless/reproducible for an individual forecast and uses wider deadbands to avoid marginal transitions.
+
+## Out-of-sample validation
+
+`regime_backtest.py` replays the legacy and validated detectors on identical frozen forecast origins. Each detector gets its own regime-labelled adaptive history, and at every origin the weighting code only receives actual target candles already observable at that time. The report includes:
+
+- MAE and direction accuracy by 2h/4h/8h/16h horizon
+- metrics segmented by detected regime
+- label distributions and transition churn for heuristic, validated-score and fixed-prototype methods
+- relative MAE change versus the legacy detector
+- a conservative safety veto when any protected horizon regresses by more than 5% by default
+
+This comparison is intended to be run before accepting material threshold changes. The same validated detector is activated by the validated production/backtest/optimizer entrypoints once this issue is merged.

--- a/regime_backtest.py
+++ b/regime_backtest.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""No-lookahead comparison of legacy and validated BTC regime detectors.
+
+Frozen model predictions are replayed chronologically. Each detector maintains
+its own history labels because adaptive weighting filters historical performance
+by regime. Only actual target candles observable by the current origin are
+passed to the weighting policy.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from correlation_weighting import correlation_aware_model_weights
+from forecast_engine import TARGET_HOURS
+from regime_detection import (
+    compare_regime_methods,
+    heuristic_regime,
+    transition_churn,
+    validated_regime,
+)
+
+DEFAULT_MAX_HORIZON_REGRESSION_PCT = 5.0
+
+
+def _weighted_ensemble_price(
+    current: float,
+    model_predictions: dict[str, dict[str, dict[str, float]]],
+    horizon: str,
+    weights: dict[str, float],
+) -> float:
+    """Mirror production's normalized weighted geometric price ensemble."""
+    weighted_log_changes = 0.0
+    total_weight = 0.0
+    for name, weight in weights.items():
+        if weight <= 0:
+            continue
+        price = float(model_predictions[name][horizon]["price_usd"])
+        weighted_log_changes += weight * math.log(price / current)
+        total_weight += weight
+    if total_weight <= 0:
+        raise ValueError("ensemble weights must contain a positive value")
+    return current * math.exp(weighted_log_changes / total_weight)
+
+
+def _score(current: float, predicted: float, actual: float) -> dict[str, float]:
+    predicted_change = predicted - current
+    actual_change = actual - current
+    return {
+        "absolute_error_pct": abs(predicted - actual) / actual * 100.0,
+        "direction_correct": float(
+            (predicted_change > 0 and actual_change > 0)
+            or (predicted_change < 0 and actual_change < 0)
+            or (predicted_change == 0 and actual_change == 0)
+        ),
+    }
+
+
+def _aggregate(scores: list[dict[str, float]]) -> dict[str, float | int | None]:
+    if not scores:
+        return {"samples": 0, "mae_pct": None, "direction_accuracy": None}
+    return {
+        "samples": len(scores),
+        "mae_pct": round(float(np.mean([item["absolute_error_pct"] for item in scores])), 6),
+        "direction_accuracy": round(
+            float(np.mean([item["direction_correct"] for item in scores])), 6
+        ),
+    }
+
+
+def _snapshot(sample: dict[str, Any], regime: str) -> dict[str, Any]:
+    forecast = sample["forecast"]
+    return {
+        "latest_close_at": forecast["latest_close_at"],
+        "latest_close_usd": forecast["latest_close_usd"],
+        "regime": regime,
+        "market_features": forecast.get("market_features", {}),
+        "model_predictions": forecast["model_predictions"],
+        "predictions": forecast.get("predictions", {}),
+        "model_weights": forecast.get("model_weights", {}),
+        "_outcomes": forecast.get("_outcomes", {}),
+    }
+
+
+def compare_detectors_out_of_sample(
+    samples: list[dict[str, Any]],
+    actual_by_timestamp: dict[int, float],
+    *,
+    history_limit: int = 200,
+    max_horizon_regression_pct: float = DEFAULT_MAX_HORIZON_REGRESSION_PCT,
+) -> dict[str, Any]:
+    """Replay old/new regime labels through the same adaptive ensemble policy."""
+    if max_horizon_regression_pct < 0:
+        raise ValueError("max_horizon_regression_pct must be non-negative")
+    ordered = sorted(samples, key=lambda item: int(item["origin_timestamp"]))
+    histories: dict[str, list[dict[str, Any]]] = {"heuristic": [], "validated": []}
+    labels: dict[str, list[str]] = {"heuristic": [], "validated": []}
+    scores: dict[str, dict[str, list[dict[str, float]]]] = {
+        policy: {f"{hour}h": [] for hour in TARGET_HOURS} for policy in histories
+    }
+    scores_by_regime: dict[str, dict[str, dict[str, list[dict[str, float]]]]] = {
+        policy: {
+            regime: {f"{hour}h": [] for hour in TARGET_HOURS}
+            for regime in ("range", "trending", "high_volatility")
+        }
+        for policy in histories
+    }
+    feature_rows: list[dict[str, Any]] = []
+
+    for sample in ordered:
+        timestamp = int(sample["origin_timestamp"])
+        current = float(sample["current_price"])
+        forecast = sample["forecast"]
+        features = dict(forecast.get("market_features") or {})
+        feature_rows.append(features)
+        policy_labels = {
+            "heuristic": heuristic_regime(features),
+            "validated": validated_regime(features),
+        }
+        visible_actuals = {
+            target: value for target, value in actual_by_timestamp.items() if target <= timestamp
+        }
+        model_predictions = forecast["model_predictions"]
+        model_names = list(model_predictions)
+
+        for policy, regime in policy_labels.items():
+            labels[policy].append(regime)
+            for hour in TARGET_HOURS:
+                horizon = f"{hour}h"
+                weights, _ = correlation_aware_model_weights(
+                    model_names,
+                    regime,
+                    hour,
+                    histories[policy],
+                    visible_actuals,
+                    history_limit=history_limit,
+                )
+                predicted = _weighted_ensemble_price(current, model_predictions, horizon, weights)
+                item = _score(current, predicted, float(sample["actuals"][horizon]))
+                scores[policy][horizon].append(item)
+                scores_by_regime[policy][regime][horizon].append(item)
+
+            histories[policy].append(_snapshot(sample, regime))
+            histories[policy] = histories[policy][-history_limit:]
+
+    by_horizon: dict[str, Any] = {}
+    regression_vetoes: list[str] = []
+    for hour in TARGET_HOURS:
+        horizon = f"{hour}h"
+        old_metrics = _aggregate(scores["heuristic"][horizon])
+        new_metrics = _aggregate(scores["validated"][horizon])
+        old_mae = old_metrics["mae_pct"]
+        new_mae = new_metrics["mae_pct"]
+        relative_regression = None
+        if old_mae is not None and new_mae is not None and float(old_mae) > 0:
+            relative_regression = (float(new_mae) / float(old_mae) - 1.0) * 100.0
+            if relative_regression > max_horizon_regression_pct:
+                regression_vetoes.append(horizon)
+        by_horizon[horizon] = {
+            "heuristic": old_metrics,
+            "validated": new_metrics,
+            "validated_minus_heuristic_mae_pct": (
+                round(float(new_mae) - float(old_mae), 6)
+                if old_mae is not None and new_mae is not None
+                else None
+            ),
+            "relative_mae_regression_pct": (
+                round(relative_regression, 4) if relative_regression is not None else None
+            ),
+        }
+
+    by_regime = {
+        policy: {
+            regime: {
+                horizon: _aggregate(regime_scores)
+                for horizon, regime_scores in horizon_scores.items()
+            }
+            for regime, horizon_scores in policy_regimes.items()
+        }
+        for policy, policy_regimes in scores_by_regime.items()
+    }
+
+    return {
+        "samples": len(ordered),
+        "history_limit": history_limit,
+        "detector_methods": compare_regime_methods(feature_rows),
+        "transition_churn": {
+            policy: transition_churn(policy_labels) for policy, policy_labels in labels.items()
+        },
+        "label_sequences": labels,
+        "by_horizon": by_horizon,
+        "by_regime": by_regime,
+        "safety_gate": {
+            "max_allowed_horizon_regression_pct": max_horizon_regression_pct,
+            "regression_veto_horizons": regression_vetoes,
+            "passes": not regression_vetoes,
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare regime detectors on frozen forecasts")
+    parser.add_argument("--samples-json", type=Path, required=True)
+    parser.add_argument("--actuals-json", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path("regime_backtest_report.json"))
+    args = parser.parse_args()
+
+    samples = json.loads(args.samples_json.read_text(encoding="utf-8"))
+    raw_actuals = json.loads(args.actuals_json.read_text(encoding="utf-8"))
+    if not isinstance(samples, list) or not isinstance(raw_actuals, dict):
+        raise ValueError("samples must be a list and actuals must be an object")
+    actuals = {int(key): float(value) for key, value in raw_actuals.items()}
+    report = compare_detectors_out_of_sample(
+        [item for item in samples if isinstance(item, dict)], actuals
+    )
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/regime_detection.py
+++ b/regime_detection.py
@@ -62,8 +62,7 @@ def regime_scores(features: dict[str, Any]) -> dict[str, float]:
     normalized_6 = abs(mom6) / max(0.20, vol6 * math.sqrt(6.0))
     normalized_7d = abs(mom7d) / max(1.0, vol7d * math.sqrt(168.0))
     direction_consistency = float(
-        (mom6 > 0 and mom24 > 0 and mom7d > 0)
-        or (mom6 < 0 and mom24 < 0 and mom7d < 0)
+        (mom6 > 0 and mom24 > 0 and mom7d > 0) or (mom6 < 0 and mom24 < 0 and mom7d < 0)
     )
     rsi_extremity = abs(rsi - 50.0) / 25.0
     trending = (
@@ -124,7 +123,10 @@ def prototype_regime(features: dict[str, Any]) -> str:
     scales = (0.55, 0.70, 0.70, 0.65)
 
     def distance(center: tuple[float, ...]) -> float:
-        return sum(((value - target) / scale) ** 2 for value, target, scale in zip(vector, center, scales, strict=True))
+        return sum(
+            ((value - target) / scale) ** 2
+            for value, target, scale in zip(vector, center, scales, strict=True)
+        )
 
     return min(prototypes, key=lambda name: distance(prototypes[name]))
 

--- a/regime_detection.py
+++ b/regime_detection.py
@@ -1,0 +1,192 @@
+"""Reproducible BTC market-regime detectors and transition diagnostics.
+
+The production candidate is a deterministic score-based state model using the
+validated feature set already emitted by ``forecast_engine.market_features``.
+The module keeps the legacy heuristic as an explicit benchmark and includes a
+fixed-prototype alternative so regime-method comparisons do not silently tune
+on the evaluation period.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import Any, Callable
+
+REGIMES = ("range", "trending", "high_volatility")
+
+
+def _float(features: dict[str, Any], name: str, default: float = 0.0) -> float:
+    try:
+        value = float(features.get(name, default))
+    except (TypeError, ValueError):
+        return default
+    return value if math.isfinite(value) else default
+
+
+def heuristic_regime(features: dict[str, Any]) -> str:
+    """Exact benchmark matching the original forecast-engine heuristic."""
+    vol24 = _float(features, "volatility_24h_pct")
+    vol7d = max(_float(features, "volatility_7d_pct"), 1e-6)
+    mom24 = abs(_float(features, "momentum_24h_pct"))
+    rsi = _float(features, "rsi_14", 50.0)
+    if vol24 > vol7d * 1.35:
+        return "high_volatility"
+    if mom24 > max(1.0, vol24 * math.sqrt(24) * 1.2) or rsi >= 70 or rsi <= 30:
+        return "trending"
+    return "range"
+
+
+def regime_scores(features: dict[str, Any]) -> dict[str, float]:
+    """Return interpretable volatility/trend/range state scores."""
+    vol6 = max(_float(features, "volatility_6h_pct"), 1e-6)
+    vol24 = max(_float(features, "volatility_24h_pct"), 1e-6)
+    vol7d = max(_float(features, "volatility_7d_pct"), 1e-6)
+    range24 = max(_float(features, "range_24h_avg_pct"), 0.0)
+    volume_z = abs(_float(features, "volume_zscore_7d"))
+    rsi = _float(features, "rsi_14", 50.0)
+    mom6 = _float(features, "momentum_6h_pct")
+    mom24 = _float(features, "momentum_24h_pct")
+    mom7d = _float(features, "momentum_7d_pct")
+
+    vol_ratio = vol24 / vol7d
+    short_vol_ratio = vol6 / vol24
+    high_volatility = (
+        0.60 * max(0.0, (vol_ratio - 1.05) / 0.45)
+        + 0.25 * max(0.0, (short_vol_ratio - 1.05) / 0.55)
+        + 0.10 * max(0.0, (range24 / max(vol24, 0.05) - 1.20) / 1.40)
+        + 0.05 * max(0.0, volume_z - 1.25)
+    )
+
+    normalized_24 = abs(mom24) / max(0.40, vol24 * math.sqrt(24.0))
+    normalized_6 = abs(mom6) / max(0.20, vol6 * math.sqrt(6.0))
+    normalized_7d = abs(mom7d) / max(1.0, vol7d * math.sqrt(168.0))
+    direction_consistency = float(
+        (mom6 > 0 and mom24 > 0 and mom7d > 0)
+        or (mom6 < 0 and mom24 < 0 and mom7d < 0)
+    )
+    rsi_extremity = abs(rsi - 50.0) / 25.0
+    trending = (
+        0.50 * normalized_24
+        + 0.20 * normalized_6
+        + 0.10 * normalized_7d
+        + 0.12 * direction_consistency
+        + 0.08 * rsi_extremity
+    )
+
+    # Range is strongest when realized volatility is not expanding and both
+    # normalized momentum and RSI displacement are muted.
+    range_score = (
+        1.0
+        - min(0.70, 0.45 * max(0.0, vol_ratio - 0.90))
+        - min(0.65, 0.40 * normalized_24)
+        - min(0.30, 0.15 * rsi_extremity)
+    )
+    return {
+        "range": max(0.0, range_score),
+        "trending": max(0.0, trending),
+        "high_volatility": max(0.0, high_volatility),
+    }
+
+
+def validated_regime(features: dict[str, Any]) -> str:
+    """Classify one feature row using conservative score thresholds/deadbands."""
+    scores = regime_scores(features)
+    high = scores["high_volatility"]
+    trend = scores["trending"]
+    # Volatility gets priority only after a material expansion. The thresholds
+    # deliberately leave a deadband around marginal states to reduce churn.
+    if high >= 0.78 and high >= trend * 0.92:
+        return "high_volatility"
+    if trend >= 0.92 and trend >= high * 0.90:
+        return "trending"
+    return "range"
+
+
+def prototype_regime(features: dict[str, Any]) -> str:
+    """Fixed-centroid alternative resembling a tiny deterministic state cluster."""
+    vol24 = max(_float(features, "volatility_24h_pct"), 1e-6)
+    vol7d = max(_float(features, "volatility_7d_pct"), 1e-6)
+    mom24 = abs(_float(features, "momentum_24h_pct"))
+    rsi = _float(features, "rsi_14", 50.0)
+    volume_z = abs(_float(features, "volume_zscore_7d"))
+    vector = (
+        min(3.0, vol24 / vol7d),
+        min(3.0, mom24 / max(0.5, vol24 * math.sqrt(24.0))),
+        min(2.0, abs(rsi - 50.0) / 25.0),
+        min(3.0, volume_z / 2.0),
+    )
+    prototypes = {
+        "range": (0.90, 0.30, 0.30, 0.30),
+        "trending": (1.00, 1.35, 1.10, 0.55),
+        "high_volatility": (1.75, 0.75, 0.70, 0.90),
+    }
+    scales = (0.55, 0.70, 0.70, 0.65)
+
+    def distance(center: tuple[float, ...]) -> float:
+        return sum(((value - target) / scale) ** 2 for value, target, scale in zip(vector, center, scales, strict=True))
+
+    return min(prototypes, key=lambda name: distance(prototypes[name]))
+
+
+def smooth_regime_sequence(
+    feature_rows: list[dict[str, Any]],
+    *,
+    detector: Callable[[dict[str, Any]], str] = validated_regime,
+    confirmation_samples: int = 2,
+) -> list[str]:
+    """Apply optional transition confirmation for offline/research sequences."""
+    if confirmation_samples < 1:
+        raise ValueError("confirmation_samples must be >= 1")
+    raw = [detector(features) for features in feature_rows]
+    if not raw or confirmation_samples == 1:
+        return raw
+    stable = raw[0]
+    candidate = stable
+    candidate_count = 0
+    output = [stable]
+    for label in raw[1:]:
+        if label == stable:
+            candidate = stable
+            candidate_count = 0
+        elif label == candidate:
+            candidate_count += 1
+            if candidate_count >= confirmation_samples:
+                stable = candidate
+                candidate_count = 0
+        else:
+            candidate = label
+            candidate_count = 1
+        output.append(stable)
+    return output
+
+
+def transition_churn(labels: list[str]) -> dict[str, float | int]:
+    """Measure how often a detector changes state across chronological samples."""
+    transitions = sum(left != right for left, right in zip(labels, labels[1:]))
+    opportunities = max(0, len(labels) - 1)
+    return {
+        "samples": len(labels),
+        "transitions": transitions,
+        "transition_rate": transitions / opportunities if opportunities else 0.0,
+    }
+
+
+def compare_regime_methods(feature_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compare legacy, score-state and fixed-prototype labels without fitting."""
+    methods: dict[str, Callable[[dict[str, Any]], str]] = {
+        "heuristic": heuristic_regime,
+        "validated_score": validated_regime,
+        "fixed_prototype": prototype_regime,
+    }
+    report: dict[str, Any] = {}
+    for name, detector in methods.items():
+        raw = [detector(features) for features in feature_rows]
+        smoothed = smooth_regime_sequence(feature_rows, detector=detector)
+        report[name] = {
+            "label_counts": dict(Counter(raw)),
+            "raw_churn": transition_churn(raw),
+            "confirmed_churn": transition_churn(smoothed),
+            "confirmed_label_counts": dict(Counter(smoothed)),
+        }
+    return report

--- a/test_regime_backtest.py
+++ b/test_regime_backtest.py
@@ -63,8 +63,7 @@ class RegimeBacktestTests(unittest.TestCase):
                 ("persistence", 0.0),
             ):
                 model_predictions[name] = {
-                    f"{hour}h": {"price_usd": current + offset}
-                    for hour in (2, 4, 8, 16)
+                    f"{hour}h": {"price_usd": current + offset} for hour in (2, 4, 8, 16)
                 }
             sample_actuals = {}
             for hour in (2, 4, 8, 16):

--- a/test_regime_backtest.py
+++ b/test_regime_backtest.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Tests for no-lookahead regime detector evaluation."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from regime_backtest import compare_detectors_out_of_sample
+
+
+def feature_row(i: int) -> dict:
+    if i % 9 in {0, 1}:
+        return {
+            "volatility_6h_pct": 1.4,
+            "volatility_24h_pct": 1.2,
+            "volatility_7d_pct": 0.55,
+            "range_24h_avg_pct": 1.7,
+            "volume_zscore_7d": 2.0,
+            "rsi_14": 56.0,
+            "momentum_6h_pct": 0.4,
+            "momentum_24h_pct": 0.7,
+            "momentum_7d_pct": 1.0,
+        }
+    if i % 9 in {4, 5, 6}:
+        return {
+            "volatility_6h_pct": 0.25,
+            "volatility_24h_pct": 0.30,
+            "volatility_7d_pct": 0.35,
+            "range_24h_avg_pct": 0.45,
+            "volume_zscore_7d": 0.5,
+            "rsi_14": 76.0,
+            "momentum_6h_pct": 1.4,
+            "momentum_24h_pct": 4.5,
+            "momentum_7d_pct": 10.0,
+        }
+    return {
+        "volatility_6h_pct": 0.30,
+        "volatility_24h_pct": 0.35,
+        "volatility_7d_pct": 0.42,
+        "range_24h_avg_pct": 0.48,
+        "volume_zscore_7d": 0.2,
+        "rsi_14": 51.0,
+        "momentum_6h_pct": 0.05,
+        "momentum_24h_pct": 0.15,
+        "momentum_7d_pct": 0.25,
+    }
+
+
+class RegimeBacktestTests(unittest.TestCase):
+    def test_report_contains_churn_regime_metrics_and_safety_gate(self) -> None:
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        samples = []
+        actuals: dict[int, float] = {}
+        for i in range(24):
+            origin = start + timedelta(hours=i * 2)
+            current = 100.0 + i * 0.1
+            model_predictions = {}
+            for name, offset in (
+                ("timesfm_168h", 0.25),
+                ("timesfm_336h", 0.26),
+                ("ar1", -0.10 if i % 2 else 0.10),
+                ("persistence", 0.0),
+            ):
+                model_predictions[name] = {
+                    f"{hour}h": {"price_usd": current + offset}
+                    for hour in (2, 4, 8, 16)
+                }
+            sample_actuals = {}
+            for hour in (2, 4, 8, 16):
+                target = int((origin + timedelta(hours=hour)).timestamp())
+                value = current + 0.15
+                actuals[target] = value
+                sample_actuals[f"{hour}h"] = value
+            samples.append(
+                {
+                    "origin_timestamp": int(origin.timestamp()),
+                    "current_price": current,
+                    "actuals": sample_actuals,
+                    "forecast": {
+                        "latest_close_at": origin.isoformat(),
+                        "latest_close_usd": current,
+                        "regime": "range",
+                        "market_features": feature_row(i),
+                        "model_predictions": model_predictions,
+                        "predictions": {},
+                    },
+                }
+            )
+
+        report = compare_detectors_out_of_sample(samples, actuals)
+        self.assertEqual(report["samples"], 24)
+        self.assertEqual(set(report["by_horizon"]), {"2h", "4h", "8h", "16h"})
+        self.assertEqual(set(report["transition_churn"]), {"heuristic", "validated"})
+        self.assertIn("validated_score", report["detector_methods"])
+        self.assertIn("passes", report["safety_gate"])
+        for horizon in report["by_horizon"].values():
+            self.assertEqual(horizon["heuristic"]["samples"], 24)
+            self.assertEqual(horizon["validated"]["samples"], 24)
+
+    def test_unobserved_future_actuals_cannot_affect_earlier_weighting(self) -> None:
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        model_predictions = {
+            name: {f"{hour}h": {"price_usd": 100.1} for hour in (2, 4, 8, 16)}
+            for name in ("timesfm_168h", "timesfm_336h", "ar1", "persistence")
+        }
+        samples = []
+        actuals: dict[int, float] = {}
+        for i in range(4):
+            origin = start + timedelta(hours=i)
+            sample_actuals = {}
+            for hour in (2, 4, 8, 16):
+                target = int((origin + timedelta(hours=hour)).timestamp())
+                actuals[target] = 100.2
+                sample_actuals[f"{hour}h"] = 100.2
+            samples.append(
+                {
+                    "origin_timestamp": int(origin.timestamp()),
+                    "current_price": 100.0,
+                    "actuals": sample_actuals,
+                    "forecast": {
+                        "latest_close_at": origin.isoformat(),
+                        "latest_close_usd": 100.0,
+                        "market_features": feature_row(i),
+                        "model_predictions": model_predictions,
+                        "predictions": {},
+                    },
+                }
+            )
+        first = compare_detectors_out_of_sample(samples, actuals)
+        future_actuals = dict(actuals)
+        future_actuals[int((start + timedelta(days=30)).timestamp())] = 100000.0
+        second = compare_detectors_out_of_sample(samples, future_actuals)
+        self.assertEqual(first, second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_regime_detection.py
+++ b/test_regime_detection.py
@@ -43,18 +43,14 @@ def features(
 
 class RegimeDetectionTests(unittest.TestCase):
     def test_legacy_heuristic_is_preserved_as_explicit_benchmark(self) -> None:
-        self.assertEqual(
-            heuristic_regime(features(vol24=1.5, vol7d=0.8)), "high_volatility"
-        )
+        self.assertEqual(heuristic_regime(features(vol24=1.5, vol7d=0.8)), "high_volatility")
         self.assertEqual(heuristic_regime(features(mom24=3.0, rsi=72.0)), "trending")
         self.assertEqual(heuristic_regime(features()), "range")
 
     def test_validated_detector_covers_all_stable_labels(self) -> None:
         self.assertEqual(validated_regime(features()), "range")
         self.assertEqual(
-            validated_regime(
-                features(vol6=1.8, vol24=1.5, vol7d=0.65, range24=2.0, volume_z=2.5)
-            ),
+            validated_regime(features(vol6=1.8, vol24=1.5, vol7d=0.65, range24=2.0, volume_z=2.5)),
             "high_volatility",
         )
         self.assertEqual(

--- a/test_regime_detection.py
+++ b/test_regime_detection.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Tests for validated market regime detection."""
+
+from __future__ import annotations
+
+import unittest
+
+from regime_detection import (
+    compare_regime_methods,
+    heuristic_regime,
+    prototype_regime,
+    regime_scores,
+    smooth_regime_sequence,
+    transition_churn,
+    validated_regime,
+)
+
+
+def features(
+    *,
+    vol6: float = 0.35,
+    vol24: float = 0.40,
+    vol7d: float = 0.45,
+    mom6: float = 0.10,
+    mom24: float = 0.20,
+    mom7d: float = 0.30,
+    rsi: float = 52.0,
+    volume_z: float = 0.2,
+    range24: float = 0.5,
+) -> dict:
+    return {
+        "volatility_6h_pct": vol6,
+        "volatility_24h_pct": vol24,
+        "volatility_7d_pct": vol7d,
+        "momentum_6h_pct": mom6,
+        "momentum_24h_pct": mom24,
+        "momentum_7d_pct": mom7d,
+        "rsi_14": rsi,
+        "volume_zscore_7d": volume_z,
+        "range_24h_avg_pct": range24,
+    }
+
+
+class RegimeDetectionTests(unittest.TestCase):
+    def test_legacy_heuristic_is_preserved_as_explicit_benchmark(self) -> None:
+        self.assertEqual(
+            heuristic_regime(features(vol24=1.5, vol7d=0.8)), "high_volatility"
+        )
+        self.assertEqual(heuristic_regime(features(mom24=3.0, rsi=72.0)), "trending")
+        self.assertEqual(heuristic_regime(features()), "range")
+
+    def test_validated_detector_covers_all_stable_labels(self) -> None:
+        self.assertEqual(validated_regime(features()), "range")
+        self.assertEqual(
+            validated_regime(
+                features(vol6=1.8, vol24=1.5, vol7d=0.65, range24=2.0, volume_z=2.5)
+            ),
+            "high_volatility",
+        )
+        self.assertEqual(
+            validated_regime(
+                features(
+                    vol6=0.25,
+                    vol24=0.30,
+                    vol7d=0.35,
+                    mom6=1.5,
+                    mom24=5.0,
+                    mom7d=12.0,
+                    rsi=78.0,
+                )
+            ),
+            "trending",
+        )
+
+    def test_scores_are_reproducible_and_non_negative(self) -> None:
+        item = features(mom24=-2.0, volume_z=-2.2)
+        self.assertEqual(regime_scores(item), regime_scores(dict(item)))
+        for score in regime_scores(item).values():
+            self.assertGreaterEqual(score, 0.0)
+
+    def test_fixed_prototype_alternative_is_deterministic(self) -> None:
+        item = features(vol24=0.8, vol7d=0.5, mom24=1.2, rsi=68.0)
+        self.assertIn(prototype_regime(item), {"range", "trending", "high_volatility"})
+        self.assertEqual(prototype_regime(item), prototype_regime(item))
+
+    def test_transition_confirmation_reduces_single_sample_churn(self) -> None:
+        rows = [
+            features(),
+            features(vol6=2.0, vol24=1.8, vol7d=0.7, range24=2.0),
+            features(),
+            features(),
+        ]
+        raw = [validated_regime(item) for item in rows]
+        confirmed = smooth_regime_sequence(rows, confirmation_samples=2)
+        self.assertLessEqual(
+            transition_churn(confirmed)["transitions"], transition_churn(raw)["transitions"]
+        )
+
+    def test_method_comparison_reports_churn_and_label_counts(self) -> None:
+        report = compare_regime_methods([features(), features(mom24=4.0, rsi=75.0)])
+        self.assertEqual(set(report), {"heuristic", "validated_score", "fixed_prototype"})
+        for metrics in report.values():
+            self.assertIn("raw_churn", metrics)
+            self.assertIn("confirmed_churn", metrics)
+            self.assertEqual(metrics["raw_churn"]["samples"], 2)
+
+    def test_missing_or_invalid_optional_values_fail_conservatively(self) -> None:
+        item = features()
+        item["volume_zscore_7d"] = "not-a-number"
+        del item["momentum_7d_pct"]
+        self.assertIn(validated_regime(item), {"range", "trending", "high_volatility"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/validated_entrypoints.py
+++ b/validated_entrypoints.py
@@ -207,6 +207,13 @@ def _activate_diversified_model(target: Any, *, research: bool) -> None:
     engine._ridge_model_enabled = enabled
 
 
+def _activate_validated_regime_detector(target: Any) -> None:
+    """Replace the legacy heuristic with the reproducible validated state detector."""
+    from regime_detection import validated_regime
+
+    target.forecast_engine.detect_regime = validated_regime
+
+
 def run_forecast(argv: list[str]) -> None:
     if argv:
         raise SystemExit("forecast does not accept positional arguments")
@@ -214,6 +221,7 @@ def run_forecast(argv: list[str]) -> None:
 
     _activate_correlation_policy(btc_forecast)
     _activate_diversified_model(btc_forecast, research=False)
+    _activate_validated_regime_detector(btc_forecast)
     observer = PipelineObserver(run_type="production_forecast")
     _instrument_forecast(observer, btc_forecast)
     try:
@@ -231,6 +239,7 @@ def _patch_backtest_fetch() -> Any:
 
     _activate_correlation_policy(backtest)
     _activate_diversified_model(backtest, research=True)
+    _activate_validated_regime_detector(backtest)
     original_fetch = backtest.fetch_binance_history
 
     def fetch_validated(days: int):


### PR DESCRIPTION
## Summary
- replace the two-rule production heuristic with a reproducible score-state detector using validated volatility, momentum, range, volume and RSI features
- preserve the stable `range`, `trending` and `high_volatility` labels used by adaptive weighting
- keep the exact legacy heuristic as an explicit benchmark and add a deterministic fixed-prototype/state alternative
- measure raw and confirmed transition churn and label distributions
- add a frozen-prediction no-lookahead evaluator that replays legacy vs validated regime histories through the same correlation-aware adaptive policy
- report MAE/direction by horizon and detected regime, plus a conservative 5% per-horizon regression veto
- activate the validated detector in production, backtest and optimizer entrypoints
- add tests, documentation and type checking

This PR is stacked after #87 / issue #32 and should be merged last.

Closes #29