### PR TITLE
Implement direction-first B1 X post template

### DIFF
--- a/format_tweet.py
+++ b/format_tweet.py
@@ -1,20 +1,17 @@
 #!/usr/bin/env python3
-"""Render a compact, emoji-rich X post from forecast.json."""
+"""Render the direction-first B1 X post from forecast.json."""
 
 from __future__ import annotations
 
 import json
+import math
+from collections import Counter
 from pathlib import Path
 from typing import Any
 
 FORECAST_PATH = Path("forecast.json")
 TWEET_PATH = Path("tweet.txt")
-
-REGIME_LABELS = {
-    "range": "↔️ Range",
-    "trending": "📈 Trending",
-    "high_volatility": "⚡ High volatility",
-}
+HORIZONS = ("2h", "4h", "8h", "16h")
 
 
 def format_price(value: float) -> str:
@@ -29,7 +26,17 @@ def direction_icon(change_pct: float) -> str:
     return "→"
 
 
+def direction_signal(change_pct: float) -> tuple[str, str]:
+    """Return the visual signal used by the B1 horizon rows."""
+    if change_pct > 0.005:
+        return "🟢", "UP"
+    if change_pct < -0.005:
+        return "🔴", "DOWN"
+    return "⚪", "FLAT"
+
+
 def horizon_text(horizon: str, prediction: dict[str, Any]) -> str:
+    """Retain the legacy horizon formatter for callers outside the tweet layout."""
     change = float(prediction["change_pct"])
     return (
         f"{horizon} {direction_icon(change)} {format_price(float(prediction['price_usd']))} "
@@ -37,52 +44,125 @@ def horizon_text(horizon: str, prediction: dict[str, Any]) -> str:
     )
 
 
-def build_visual_tweet(output: dict[str, Any]) -> str:
+def _format_number(value: float, decimals: int = 2) -> str:
+    """Format signed percentages compactly, including pathological large values."""
+    if not math.isfinite(value):
+        return f"{value:+g}"
+    if abs(value) >= 1000:
+        return f"{value:+.1e}"
+    return f"{value:+.{decimals}f}"
+
+
+def format_move(value: float, decimals: int = 2) -> str:
+    return f"{_format_number(value, decimals)}%"
+
+
+def format_delta(value: float, decimals: int = 2) -> str:
+    return f"{_format_number(value, decimals)}pp"
+
+
+def previous_outcome_text(score: dict[str, Any] | None, *, compact: bool = False) -> str:
+    """Render previous predicted move, actual move and actual-predicted delta."""
+    if not score:
+        return "Prev …" if not compact else "…"
+
+    try:
+        predicted = float(score["predicted_change_pct"])
+        actual = float(score["actual_change_pct"])
+    except (KeyError, TypeError, ValueError):
+        return "Prev …" if not compact else "…"
+
+    delta = actual - predicted
+    direction_correct = score.get("direction_correct")
+    if direction_correct is None:
+        direction_correct = (
+            (predicted > 0) == (actual > 0) if predicted and actual else predicted == actual
+        )
+    mark = "✅" if bool(direction_correct) else "❌"
+    decimals = 1 if compact else 2
+
+    if compact:
+        return (
+            f"{mark} P{format_move(predicted, decimals)} "
+            f"A{format_move(actual, decimals)} Δ{format_delta(delta, decimals)}"
+        )
+    return (
+        f"Prev {mark} P{format_move(predicted, decimals)} "
+        f"A{format_move(actual, decimals)} Δ{format_delta(delta, decimals)}"
+    )
+
+
+def signal_row(
+    horizon: str,
+    prediction: dict[str, Any],
+    score: dict[str, Any] | None,
+    *,
+    compact: bool = False,
+) -> str:
+    change = float(prediction["change_pct"])
+    emoji, label = direction_signal(change)
+    decimals = 1 if compact else 2
+    current = format_move(change, decimals)
+
+    if compact:
+        return f"{horizon} {emoji}{current} | {previous_outcome_text(score, compact=True)}"
+    return f"{horizon} {emoji} {label} {current} | {previous_outcome_text(score)}"
+
+
+def consensus_text(predictions: dict[str, Any]) -> str:
+    labels = [direction_signal(float(predictions[h]["change_pct"]))[1] for h in HORIZONS]
+    counts = Counter(labels)
+    best_count = max(counts.values())
+    winners = [label for label, count in counts.items() if count == best_count]
+
+    if len(winners) != 1:
+        return "🤝 mixed outlook"
+
+    label = winners[0]
+    description = {"UP": "bullish", "DOWN": "bearish", "FLAT": "neutral"}[label]
+    return f"🤝 {best_count}/4 {description}"
+
+
+def _render_tweet(
+    output: dict[str, Any],
+    *,
+    compact: bool,
+    include_consensus: bool,
+    include_price: bool,
+) -> str:
     predictions = output["predictions"]
     reliability = output.get("forecast_reliability", {})
-    regime = str(output.get("regime", "range"))
-    regime_text = REGIME_LABELS.get(regime, f"🧭 {regime.replace('_', ' ').title()}")
 
-    agreements = [
-        float(predictions[h].get("model_agreement", 0.0))
-        for h in ("2h", "4h", "8h", "16h")
-        if h in predictions
-    ]
-    average_agreement = sum(agreements) / len(agreements) if agreements else 0.0
+    lines = ["₿ BTC SIGNAL"]
+    lines.extend(
+        signal_row(horizon, predictions[horizon], reliability.get(horizon), compact=compact)
+        for horizon in HORIZONS
+    )
+    if include_consensus:
+        lines.append(consensus_text(predictions))
 
-    errors: list[str] = []
-    for horizon in ("2h", "4h", "8h", "16h"):
-        score = reliability.get(horizon)
-        errors.append(
-            f"{horizon} {float(score['absolute_error_pct']):.2f}%" if score else f"{horizon} —"
-        )
+    if include_price:
+        lines.append(f"💰 {format_price(float(output['latest_close_usd']))} • ⚠️ Experimental • NFA")
+    else:
+        lines.append("⚠️ Experimental • NFA")
+    return "\n".join(lines)
 
-    lines = [
-        "₿ BTC/USD • Ensemble",
-        f"💰 Now {format_price(float(output['latest_close_usd']))} • {regime_text}",
-        "⏱ " + " | ".join(horizon_text(h, predictions[h]) for h in ("2h", "4h")),
-        "🔭 " + " | ".join(horizon_text(h, predictions[h]) for h in ("8h", "16h")),
-        f"🤝 Models {average_agreement * 100:.0f}% agree",
-        "🎯 Error: " + " | ".join(errors),
-        "⚠️ Experimental • NFA",
-    ]
 
-    tweet = "\n".join(lines)
+def build_visual_tweet(output: dict[str, Any]) -> str:
+    """Build the selected B1 direction-first template with deterministic fallbacks."""
+    attempts = (
+        dict(compact=False, include_consensus=True, include_price=True),
+        dict(compact=False, include_consensus=False, include_price=True),
+        dict(compact=False, include_consensus=False, include_price=False),
+        dict(compact=True, include_consensus=False, include_price=False),
+    )
 
-    # Keep graceful fallbacks in case larger BTC prices or future labels make the post longer.
-    if len(tweet) > 280:
-        lines.pop(4)  # remove model-agreement line first
-        tweet = "\n".join(lines)
-    if len(tweet) > 280:
-        lines[1] = f"💰 {format_price(float(output['latest_close_usd']))} • {regime_text}"
-        tweet = "\n".join(lines)
-    if len(tweet) > 280:
-        lines[-2] = "🎯 Error: " + " | ".join(errors[:2])
-        tweet = "\n".join(lines)
-    if len(tweet) > 280:
-        raise RuntimeError(f"Generated X post is too long: {len(tweet)} characters")
+    for options in attempts:
+        tweet = _render_tweet(output, **options)
+        if len(tweet) <= 280:
+            return tweet
 
-    return tweet
+    raise RuntimeError("Generated X post is too long even after compact fallback")
 
 
 def main() -> None:

--- a/test_format_tweet.py
+++ b/test_format_tweet.py
@@ -1,26 +1,43 @@
 #!/usr/bin/env python3
-"""Unit tests for the emoji-rich X post formatter."""
+"""Unit tests for the direction-first B1 X post formatter."""
 
 from __future__ import annotations
 
 import unittest
 
-from format_tweet import build_visual_tweet, direction_icon, horizon_text
+from format_tweet import (
+    build_visual_tweet,
+    consensus_text,
+    direction_icon,
+    direction_signal,
+    horizon_text,
+    previous_outcome_text,
+)
 
 
-def sample_output(*, regime: str = "range") -> dict:
+def _score(predicted: float, actual: float, correct: bool) -> dict:
+    return {
+        "predicted_change_pct": predicted,
+        "actual_change_pct": actual,
+        "direction_correct": correct,
+        "absolute_error_pct": abs(actual - predicted),
+    }
+
+
+def sample_output() -> dict:
     return {
         "latest_close_usd": 79_733.0,
-        "regime": regime,
+        "regime": "range",
         "predictions": {
-            "2h": {"price_usd": 79_735.0, "change_pct": 0.003, "model_agreement": 0.4},
-            "4h": {"price_usd": 79_739.0, "change_pct": 0.008, "model_agreement": 0.4},
-            "8h": {"price_usd": 79_751.0, "change_pct": 0.023, "model_agreement": 0.8},
-            "16h": {"price_usd": 79_780.0, "change_pct": 0.060, "model_agreement": 0.8},
+            "2h": {"price_usd": 79_813.0, "change_pct": 0.10, "model_agreement": 0.8},
+            "4h": {"price_usd": 79_877.0, "change_pct": 0.18, "model_agreement": 0.8},
+            "8h": {"price_usd": 80_004.0, "change_pct": 0.34, "model_agreement": 0.8},
+            "16h": {"price_usd": 80_307.0, "change_pct": 0.72, "model_agreement": 0.8},
         },
         "forecast_reliability": {
-            "2h": {"absolute_error_pct": 0.136},
-            "4h": {"absolute_error_pct": 0.135},
+            "2h": _score(0.12, 0.07, True),
+            "4h": _score(0.15, 0.22, True),
+            "8h": _score(0.20, -0.11, False),
         },
     }
 
@@ -32,33 +49,73 @@ class VisualTweetTests(unittest.TestCase):
         self.assertEqual(direction_icon(0.005), "→")
         self.assertEqual(direction_icon(-0.005), "→")
 
-    def test_horizon_text_formats_price_and_change(self) -> None:
+    def test_direction_signal_labels(self) -> None:
+        self.assertEqual(direction_signal(0.10), ("🟢", "UP"))
+        self.assertEqual(direction_signal(-0.10), ("🔴", "DOWN"))
+        self.assertEqual(direction_signal(0.001), ("⚪", "FLAT"))
+
+    def test_horizon_text_keeps_legacy_format(self) -> None:
         self.assertEqual(
             horizon_text("4h", {"price_usd": 80123.7, "change_pct": -0.42}),
             "4h ↘ $80,124 (-0.42%)",
         )
 
-    def test_visual_tweet_contains_key_signals_and_stays_within_limit(self) -> None:
+    def test_previous_outcome_includes_predicted_actual_and_delta(self) -> None:
+        text = previous_outcome_text(_score(0.12, 0.07, True))
+        self.assertEqual(text, "Prev ✅ P+0.12% A+0.07% Δ-0.05pp")
+
+    def test_previous_outcome_handles_wrong_direction_and_positive_delta(self) -> None:
+        text = previous_outcome_text(_score(-0.20, 0.11, False))
+        self.assertEqual(text, "Prev ❌ P-0.20% A+0.11% Δ+0.31pp")
+
+    def test_previous_outcome_missing_or_legacy_score_is_pending(self) -> None:
+        self.assertEqual(previous_outcome_text(None), "Prev …")
+        self.assertEqual(previous_outcome_text({"absolute_error_pct": 0.2}), "Prev …")
+
+    def test_b1_tweet_contains_direction_and_accountability(self) -> None:
         tweet = build_visual_tweet(sample_output())
         self.assertLessEqual(len(tweet), 280)
-        self.assertIn("₿ BTC/USD • Ensemble", tweet)
-        self.assertIn("↔️ Range", tweet)
-        self.assertIn("🤝 Models 60% agree", tweet)
-        self.assertIn("🎯 Error: 2h 0.14% | 4h 0.14% | 8h — | 16h —", tweet)
-        self.assertIn("⚠️ Experimental • NFA", tweet)
+        self.assertIn("₿ BTC SIGNAL", tweet)
+        self.assertIn("2h 🟢 UP +0.10% | Prev ✅ P+0.12% A+0.07% Δ-0.05pp", tweet)
+        self.assertIn("4h 🟢 UP +0.18% | Prev ✅ P+0.15% A+0.22% Δ+0.07pp", tweet)
+        self.assertIn("8h 🟢 UP +0.34% | Prev ❌ P+0.20% A-0.11% Δ-0.31pp", tweet)
+        self.assertIn("16h 🟢 UP +0.72% | Prev …", tweet)
+        self.assertIn("🤝 4/4 bullish", tweet)
+        self.assertIn("💰 $79,733 • ⚠️ Experimental • NFA", tweet)
 
-    def test_unknown_regime_gets_readable_fallback_label(self) -> None:
-        tweet = build_visual_tweet(sample_output(regime="breakout_watch"))
-        self.assertIn("🧭 Breakout Watch", tweet)
+    def test_bearish_neutral_and_mixed_current_signals(self) -> None:
+        output = sample_output()
+        output["predictions"]["2h"]["change_pct"] = -0.20
+        output["predictions"]["4h"]["change_pct"] = -0.10
+        output["predictions"]["8h"]["change_pct"] = 0.001
+        output["predictions"]["16h"]["change_pct"] = 0.002
 
-    def test_long_regime_drops_agreement_before_exceeding_x_limit(self) -> None:
-        tweet = build_visual_tweet(sample_output(regime="x" * 60))
+        tweet = build_visual_tweet(output)
+        self.assertIn("2h 🔴 DOWN -0.20%", tweet)
+        self.assertIn("8h ⚪ FLAT +0.00%", tweet)
+        self.assertIn("🤝 mixed outlook", tweet)
+
+    def test_consensus_reports_dominant_direction(self) -> None:
+        predictions = sample_output()["predictions"]
+        predictions["16h"]["change_pct"] = -0.1
+        self.assertEqual(consensus_text(predictions), "🤝 3/4 bullish")
+
+    def test_long_numbers_use_deterministic_compact_fallback(self) -> None:
+        output = sample_output()
+        for horizon in output["predictions"]:
+            output["predictions"][horizon]["change_pct"] = 1.23456789e120
+            output["forecast_reliability"][horizon] = _score(
+                1.23456789e120,
+                -9.87654321e119,
+                False,
+            )
+
+        tweet = build_visual_tweet(output)
         self.assertLessEqual(len(tweet), 280)
-        self.assertNotIn("🤝 Models", tweet)
-
-    def test_extreme_regime_length_raises_instead_of_posting_oversize_text(self) -> None:
-        with self.assertRaises(RuntimeError):
-            build_visual_tweet(sample_output(regime="x" * 400))
+        self.assertIn("P+1.2e+120%", tweet)
+        self.assertIn("A-9.9e+119%", tweet)
+        self.assertIn("Δ-2.2e+120pp", tweet)
+        self.assertIn("⚠️ Experimental • NFA", tweet)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace the current price-first tweet with the selected direction-first B1 horizon-row layout
- show current UP/DOWN/FLAT signal and expected move for 2h/4h/8h/16h
- show matured previous-call accountability inline: direction hit/miss, predicted move, actual move, and `actual - predicted` delta in percentage points
- render unavailable/unmatured prior outcomes as pending without failing
- add deterministic <=280-character fallbacks while preserving direction and prior P/A/Δ fields
- keep the experimental/NFA disclaimer and current BTC price as secondary context
- expand formatter tests for bullish, bearish, neutral, mixed, correct/incorrect prior direction, positive/negative deltas, partial maturity and extreme values

Closes #89