### PR TITLE
Run one-off production forecast manually

### DIFF
--- a/.github/workflows/_manual_forecast_dispatch.yml
+++ b/.github/workflows/_manual_forecast_dispatch.yml
@@ -1,0 +1,20 @@
+name: One-off manual forecast dispatch
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/_manual_forecast_dispatch.yml'
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch production forecast with X posting enabled
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run forecast.yml --repo "$GITHUB_REPOSITORY" --ref main -f post_to_x=true


### PR DESCRIPTION
Adds a temporary one-off workflow that dispatches `forecast.yml` on `main` with `post_to_x=true` when merged. This is only to execute and verify the production forecast after the history-schema fix; it will be removed immediately afterwards.