### PR TITLE
Recover confirmed-unposted X forecast and rerun

### DIFF
--- a/.github/workflows/_recover_and_dispatch_x.yml
+++ b/.github/workflows/_recover_and_dispatch_x.yml
@@ -1,0 +1,79 @@
+name: One-off recover confirmed-unposted X forecast
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/_recover_and_dispatch_x.yml'
+
+permissions:
+  actions: write
+  contents: write
+
+jobs:
+  recover-and-dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Recover only the confirmed-unposted ambiguous reservation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HISTORY_RELEASE_TAG: forecast-history-v1
+          TARGET_RUN_ID: '34024457632'
+        run: |
+          set -euo pipefail
+          mkdir -p .state
+          gh release download "$HISTORY_RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern 'x_post_registry.json' \
+            --dir .state
+
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          path = Path('.state/x_post_registry.json')
+          payload = json.loads(path.read_text(encoding='utf-8'))
+          posts = payload.get('posts')
+          if not isinstance(posts, dict):
+              raise SystemExit('registry has no posts mapping')
+
+          target_run = os.environ['TARGET_RUN_ID']
+          matches = [
+              (key, value)
+              for key, value in posts.items()
+              if isinstance(value, dict)
+              and str(value.get('github_run_id')) == target_run
+              and value.get('status') == 'ambiguous'
+          ]
+          if len(matches) != 1:
+              raise SystemExit(
+                  f'expected exactly one ambiguous reservation for run {target_run}, found {len(matches)}'
+              )
+
+          key, record = matches[0]
+          posts.pop(key)
+          recoveries = payload.setdefault('operator_recoveries', [])
+          if not isinstance(recoveries, list):
+              raise SystemExit('operator_recoveries exists but is not a list')
+          recoveries.append(
+              {
+                  'recovered_at': datetime.now(timezone.utc).isoformat(),
+                  'reason': 'operator confirmed the X post was not created',
+                  'target_github_run_id': target_run,
+                  'idempotency_key': key,
+                  'previous_record': record,
+              }
+          )
+          path.write_text(json.dumps(payload, indent=2, sort_keys=True) + '\n', encoding='utf-8')
+          print(f'Recovered ambiguous reservation {key} from run {target_run}')
+          PY
+
+          gh release upload "$HISTORY_RELEASE_TAG" .state/x_post_registry.json \
+            --repo "$GITHUB_REPOSITORY" --clobber
+
+      - name: Dispatch fresh production forecast with X posting enabled
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run forecast.yml --repo "$GITHUB_REPOSITORY" --ref main -f post_to_x=true


### PR DESCRIPTION
The previous manual production forecast (GitHub run 34024457632 / forecast run #15) was marked `ambiguous` after Twikit response parsing failed, but the operator has confirmed that no X post was created.

This one-off workflow safely removes only that exact ambiguous active reservation from the durable X registry, preserves the original record under `operator_recoveries` for auditability, uploads the repaired registry, and dispatches a fresh production forecast with X posting enabled.

It intentionally targets exactly one record by GitHub run ID and fails closed if the expected record is not found.