### PR TITLE
Fix scheduled X posting cadence

### DIFF
--- a/.github/workflows/forecast.yml
+++ b/.github/workflows/forecast.yml
@@ -9,9 +9,9 @@ on:
         default: false
         type: boolean
   schedule:
-    # Wake up hourly away from the top of the hour. A guard below only runs
-    # the expensive forecast when at least two completed candle hours elapsed.
-    - cron: "37 * * * *"
+    # Wake up every two hours away from the top of the hour. A guard below uses
+    # durable X publication state so delayed/dropped cron runs catch up safely.
+    - cron: "37 */2 * * *"
 
 permissions:
   # Read the source and update the dedicated forecast-history Release assets.
@@ -46,6 +46,20 @@ jobs:
           key: btc-forecast-state-${{ github.run_id }}
           restore-keys: |
             btc-forecast-state-
+
+      - name: Restore durable X schedule state
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p .state
+          if gh release view "$HISTORY_RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release download "$HISTORY_RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern 'x_post_registry.json' \
+              --dir .state >/dev/null 2>&1 || true
+          fi
 
       - name: Decide whether forecast is due
         id: due

--- a/README.md
+++ b/README.md
@@ -262,14 +262,14 @@ For each horizon the project tracks absolute USD error, MAE %, signed error/bias
 
 ## Schedule
 
-GitHub Actions wakes up hourly at minute `37` UTC:
+GitHub Actions wakes up every two hours at minute `37` UTC:
 
 ```yaml
 schedule:
-  - cron: "37 * * * *"
+  - cron: "37 */2 * * *"
 ```
 
-A lightweight guard restores the rolling scheduler state first. The expensive forecast only runs after at least two completed candle-hours have elapsed since the previous saved forecast. This gives GitHub another opportunity every hour if a scheduled event is delayed or dropped while still producing roughly one forecast every two hours.
+A lightweight guard restores durable X posting state first. The expensive forecast only runs after at least two hours have elapsed since the previous successful X post. Manual non-posting runs can update forecast history without resetting the production X posting cadence.
 
 When a forecast is due, the durable Release database is restored before model execution, updated and verified after the forecast, and published back before any X post is sent.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,7 +36,7 @@ The project has moved beyond a TimesFM experiment into a small forecasting platf
 - **Weekly recommendation-only optimizer** that evaluates bounded candidate ensemble parameters and consumes statistical evidence.
 - **Structured production observability** with JSON snapshots, JSONL events, timings, counters, run identifiers, and GitHub Actions summaries.
 - **Daily forecast performance dashboard** generated from durable history in JSON, Markdown, and standalone HTML.
-- **Scheduled GitHub Actions production workflow** with a guard targeting roughly one forecast every two completed candle hours.
+- **Scheduled GitHub Actions production workflow** with a guard targeting roughly one X post every two hours based on durable successful-publication state.
 - **Automatic X posting** for scheduled forecasts using Twikit and the `X_COOKIES_JSON` repository secret.
 - **Emoji-rich tweet formatting** with compact 280-character fallbacks.
 - **PR CI quality gates** for unit tests, coverage, Ruff lint/format, and mypy checks.
@@ -126,9 +126,9 @@ Bitstamp BTC/USD fallback ─────┘
 
 ### Production scheduling
 
-The GitHub Actions forecast workflow wakes up hourly at minute `37` UTC. A lightweight scheduler guard checks the latest completed forecast candle and only runs the expensive model when at least two completed hourly candles have elapsed.
+The GitHub Actions forecast workflow wakes up every two hours at minute `37` UTC. A lightweight scheduler guard checks durable X publication state and only runs the expensive model when at least two hours have elapsed since the last successful X post.
 
-This design is intentional: GitHub scheduled workflows are best-effort and can be delayed. Waking hourly gives the project another chance to run without producing an expensive forecast every hour.
+This design is intentional: GitHub scheduled workflows are best-effort and can be delayed. The guard keys off successful X posts rather than saved forecasts, so failed posts and manual non-posting runs do not advance the production posting cadence.
 
 Scheduled forecasts post to X automatically. Manual runs only post when explicitly requested.
 

--- a/docs/X_POSTING.md
+++ b/docs/X_POSTING.md
@@ -11,7 +11,7 @@ Each publication gets a deterministic key derived from:
 
 The SHA-256 key is stable across retries. Re-running the same forecast with the same text therefore resolves to the same registry record.
 
-The registry is stored as `.state/x_post_registry.json` and uploaded to the same machine-managed GitHub Release used for forecast history. Records include the forecast origin, content digest, experiment/configuration IDs, GitHub Actions run ID, attempt count, provider, status and final X post ID when available.
+The registry is stored as `.state/x_post_registry.json` and uploaded to the same machine-managed GitHub Release used for forecast history. Records include the forecast origin, content digest, experiment/configuration IDs, GitHub Actions run ID, attempt count, provider, status and final X post ID when available. The registry also stores `last_successful_x_post_at`; scheduled runs use that timestamp, not the last forecast timestamp, to decide whether the next production post is due. Manual non-posting runs therefore do not reset the scheduled posting cadence.
 
 ## Two-phase publication
 

--- a/src/btc_timesfm/ops/schedule_guard.py
+++ b/src/btc_timesfm/ops/schedule_guard.py
@@ -2,9 +2,9 @@
 """Decide whether a scheduled forecast is due.
 
 GitHub Actions cron runs are best-effort and may be delayed or dropped. The
-workflow therefore wakes up hourly, restores the latest forecast history, and
-uses this guard to run the expensive forecast only when at least two completed
-hourly candles have elapsed since the last saved forecast.
+workflow therefore wakes up on a two-hour cadence, restores durable X posting
+state, and uses this guard to run the expensive forecast only when at least two
+hours have elapsed since the last successful X publication.
 
 Manual workflow_dispatch runs always proceed.
 """
@@ -18,7 +18,8 @@ from pathlib import Path
 from typing import Any
 
 STATE_PATH = Path(".state/previous_forecast.json")
-MIN_CANDLE_GAP_HOURS = 2
+X_POST_REGISTRY_PATH = Path(".state/x_post_registry.json")
+MIN_POST_GAP_HOURS = 2
 
 
 def parse_timestamp(value: Any) -> datetime | None:
@@ -59,6 +60,36 @@ def latest_forecast_close(state_path: Path) -> datetime | None:
     return max(timestamps) if timestamps else None
 
 
+def latest_successful_x_post(registry_path: Path) -> datetime | None:
+    if not registry_path.exists():
+        return None
+
+    try:
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    if not isinstance(registry, dict):
+        return None
+
+    timestamps = []
+    root_timestamp = parse_timestamp(registry.get("last_successful_x_post_at"))
+    if root_timestamp is not None:
+        timestamps.append(root_timestamp)
+
+    posts = registry.get("posts")
+    if isinstance(posts, dict):
+        timestamps.extend(
+            parsed
+            for item in posts.values()
+            if isinstance(item, dict)
+            and item.get("status") == "posted"
+            and (parsed := parse_timestamp(item.get("posted_at"))) is not None
+        )
+
+    return max(timestamps) if timestamps else None
+
+
 def completed_hour(now: datetime) -> datetime:
     now = now.astimezone(timezone.utc)
     return now.replace(minute=0, second=0, microsecond=0)
@@ -67,36 +98,45 @@ def completed_hour(now: datetime) -> datetime:
 def should_run(
     event_name: str,
     state_path: Path = STATE_PATH,
+    x_post_registry_path: Path = X_POST_REGISTRY_PATH,
     now: datetime | None = None,
 ) -> tuple[bool, str]:
+    # Keep state_path in the public signature for compatibility with older tests
+    # and local callers; scheduled X cadence is now controlled by the registry.
+    _ = state_path
+
     if event_name != "schedule":
-        return True, "Manual/non-scheduled run: forecast will run."
-
-    last_close = latest_forecast_close(state_path)
-    if last_close is None:
-        return True, "No usable forecast history found: forecast will run."
-
-    current_close = completed_hour(now or datetime.now(timezone.utc))
-    candle_gap_hours = (current_close - last_close).total_seconds() / 3600.0
-
-    if candle_gap_hours >= MIN_CANDLE_GAP_HOURS:
         return (
             True,
-            f"Forecast is due: {candle_gap_hours:.1f} completed candle hours since "
-            f"{last_close.isoformat()}.",
+            "Manual/non-scheduled run: forecast will run without controlling schedule cadence.",
+        )
+
+    checked_at = now or datetime.now(timezone.utc)
+    last_post = latest_successful_x_post(x_post_registry_path)
+    if last_post is None:
+        return True, "No successful X publication history found: forecast will run."
+
+    post_gap_hours = (checked_at.astimezone(timezone.utc) - last_post).total_seconds() / 3600.0
+
+    if post_gap_hours >= MIN_POST_GAP_HOURS:
+        return (
+            True,
+            f"Forecast is due: {post_gap_hours:.1f} hours since the last successful X post "
+            f"at {last_post.isoformat()}.",
         )
 
     return (
         False,
-        f"Forecast not due yet: {candle_gap_hours:.1f} completed candle hours since "
-        f"{last_close.isoformat()} (need {MIN_CANDLE_GAP_HOURS}).",
+        f"Forecast not due yet: {post_gap_hours:.1f} hours since the last successful X post "
+        f"at {last_post.isoformat()} (need {MIN_POST_GAP_HOURS}).",
     )
 
 
 def main() -> None:
     event_name = os.environ.get("GITHUB_EVENT_NAME", "")
     state_path = Path(os.environ.get("FORECAST_STATE_PATH", str(STATE_PATH)))
-    run_forecast, reason = should_run(event_name, state_path)
+    x_post_registry_path = Path(os.environ.get("X_POST_REGISTRY_PATH", str(X_POST_REGISTRY_PATH)))
+    run_forecast, reason = should_run(event_name, state_path, x_post_registry_path)
 
     print(reason)
 

--- a/src/btc_timesfm/x/x_post_registry.py
+++ b/src/btc_timesfm/x/x_post_registry.py
@@ -39,7 +39,7 @@ class XPostRegistry:
 
     def _load(self) -> dict[str, Any]:
         if not self.path.exists():
-            return {"version": REGISTRY_VERSION, "posts": {}}
+            return {"version": REGISTRY_VERSION, "posts": {}, "last_successful_x_post_at": None}
         payload = json.loads(self.path.read_text(encoding="utf-8"))
         if not isinstance(payload, dict):
             raise RuntimeError("X post registry must contain a JSON object")
@@ -51,7 +51,17 @@ class XPostRegistry:
         posts = payload.get("posts")
         if not isinstance(posts, dict):
             raise RuntimeError("X post registry is missing its posts mapping")
+        payload.setdefault("last_successful_x_post_at", self._latest_posted_at(posts))
         return payload
+
+    @staticmethod
+    def _latest_posted_at(posts: dict[str, Any]) -> str | None:
+        posted_times = [
+            str(item["posted_at"])
+            for item in posts.values()
+            if isinstance(item, dict) and item.get("status") == "posted" and item.get("posted_at")
+        ]
+        return max(posted_times) if posted_times else None
 
     def _save(self) -> None:
         tmp = self.path.with_suffix(self.path.suffix + ".tmp")
@@ -131,6 +141,7 @@ class XPostRegistry:
                 "updated_at": now,
             }
         )
+        self.data["last_successful_x_post_at"] = now
         self._save()
         return dict(record)
 

--- a/tests/ops/test_schedule_guard.py
+++ b/tests/ops/test_schedule_guard.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from btc_timesfm.ops.schedule_guard import (
     completed_hour,
     latest_forecast_close,
+    latest_successful_x_post,
     parse_timestamp,
     should_run,
 )
@@ -83,34 +84,67 @@ class ScheduleGuardTests(unittest.TestCase):
         self.assertTrue(run)
         self.assertIn("Manual", reason)
 
-    def test_scheduled_run_without_history_proceeds(self) -> None:
+    def test_latest_successful_x_post_prefers_root_and_post_records(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            run, reason = should_run("schedule", Path(tmp) / "missing.json")
-            self.assertTrue(run)
-            self.assertIn("No usable", reason)
-
-    def test_scheduled_run_waits_for_two_completed_candles(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "state.json"
+            path = Path(tmp) / "registry.json"
             path.write_text(
-                json.dumps({"forecasts": [{"latest_close_at": "2026-09-05T09:00:00+00:00"}]}),
+                json.dumps(
+                    {
+                        "last_successful_x_post_at": "2026-09-05T09:00:00+00:00",
+                        "posts": {
+                            "old": {
+                                "status": "posted",
+                                "posted_at": "2026-09-05T08:00:00+00:00",
+                            },
+                            "new": {
+                                "status": "posted",
+                                "posted_at": "2026-09-05T10:00:00Z",
+                            },
+                            "failed": {
+                                "status": "failed",
+                                "posted_at": "2026-09-05T11:00:00Z",
+                            },
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                latest_successful_x_post(path),
+                datetime(2026, 9, 5, 10, 0, tzinfo=timezone.utc),
+            )
+
+    def test_scheduled_run_without_x_post_history_proceeds(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            run, reason = should_run("schedule", Path(tmp) / "forecast.json", Path(tmp) / "x.json")
+            self.assertTrue(run)
+            self.assertIn("No successful X publication", reason)
+
+    def test_scheduled_run_waits_for_two_hours_since_last_successful_x_post(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            forecast_path = Path(tmp) / "state.json"
+            registry_path = Path(tmp) / "x_post_registry.json"
+            registry_path.write_text(
+                json.dumps({"last_successful_x_post_at": "2026-09-05T09:00:00+00:00"}),
                 encoding="utf-8",
             )
             run, reason = should_run(
                 "schedule",
-                path,
-                now=datetime(2026, 9, 5, 10, 59, tzinfo=timezone.utc),
+                forecast_path,
+                registry_path,
+                now=datetime(2026, 9, 5, 10, 29, tzinfo=timezone.utc),
             )
             self.assertFalse(run)
-            self.assertIn("1.0 completed", reason)
+            self.assertIn("1.5 hours", reason)
 
             run, reason = should_run(
                 "schedule",
-                path,
+                forecast_path,
+                registry_path,
                 now=datetime(2026, 9, 5, 11, 1, tzinfo=timezone.utc),
             )
             self.assertTrue(run)
-            self.assertIn("2.0 completed", reason)
+            self.assertIn("2.0 hours", reason)
 
 
 if __name__ == "__main__":

--- a/tests/x/test_post_to_x.py
+++ b/tests/x/test_post_to_x.py
@@ -179,6 +179,7 @@ class PostToXTests(unittest.TestCase):
             self.assertEqual(item["status"], "posted")
             self.assertEqual(item["experiment_run_id"], "exp-1")
             self.assertEqual(item["github_run_id"], "100")
+            self.assertIsNotNone(records.data["last_successful_x_post_at"])
 
     def test_ambiguous_response_failure_locks_future_retry(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/x/test_x_post_registry.py
+++ b/tests/x/test_x_post_registry.py
@@ -32,6 +32,7 @@ class XPostRegistryTests(unittest.TestCase):
             )
             self.assertEqual(first["action"], "publish")
             registry.mark_posted(key, "123")
+            self.assertIsNotNone(registry.data["last_successful_x_post_at"])
 
             second = XPostRegistry(path).reserve(
                 key=key,
@@ -43,6 +44,28 @@ class XPostRegistryTests(unittest.TestCase):
             )
             self.assertEqual(second["action"], "duplicate")
             self.assertEqual(second["record"]["post_id"], "123")
+
+    def test_loading_legacy_registry_backfills_last_successful_post_timestamp(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "registry.json"
+            path.write_text(
+                """{
+  "version": 1,
+  "posts": {
+    "old": {"status": "posted", "posted_at": "2026-09-05T20:00:00+00:00"},
+    "new": {"status": "posted", "posted_at": "2026-09-05T22:00:00+00:00"},
+    "failed": {"status": "failed", "posted_at": "2026-09-05T23:00:00+00:00"}
+  }
+}
+""",
+                encoding="utf-8",
+            )
+
+            registry = XPostRegistry(path)
+            self.assertEqual(
+                registry.data["last_successful_x_post_at"],
+                "2026-09-05T22:00:00+00:00",
+            )
 
     def test_ambiguous_attempt_is_locked_but_auth_failure_can_retry(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- schedule forecast workflow every 2 hours and restore durable X registry before schedule decisions
- track last_successful_x_post_at in the X post registry, with legacy backfill
- make schedule_guard use successful X post history instead of forecast history so failed posts and manual non-posting runs don't advance cadence
- update docs and regression tests

## Verification
- PYTHONPATH=src .venv/bin/python -m unittest tests.ops.test_schedule_guard tests.x.test_x_post_registry tests.x.test_post_to_x
- .venv/bin/ruff check src/btc_timesfm/ops/schedule_guard.py src/btc_timesfm/x/x_post_registry.py tests/ops/test_schedule_guard.py tests/x/test_x_post_registry.py tests/x/test_post_to_x.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/forecast.yml"); puts "YAML OK"'